### PR TITLE
feat(office): 办公室 UI 原型 (Office/AgentCanvas)

### DIFF
--- a/app/src/components/Workspace.tsx
+++ b/app/src/components/Workspace.tsx
@@ -30,7 +30,7 @@ import { installArtifactBridge } from '../lib/artifactBridge';
 import { WindowManager } from './terminal/WindowManager';
 import { VoiceFloatingButton } from './VoiceFloatingButton';
 import TeamPanel from './layout/TeamPanel';
-import MeetingRoom from './office/MeetingRoom';
+import Office from './office/Office';
 import GlobalProxyIndicator from './layout/GlobalProxyIndicator';
 import SkillMarketplacePanel from './layout/SkillMarketplacePanel';
 import AgentInspector, { InspectorTab } from './layout/AgentInspector';
@@ -1794,7 +1794,7 @@ export default function Workspace({ agentId, onSelectAgent }: Props) {
               </div>
             ) : null}
             <div data-testid="right-panel" data-id="right-panel" className="min-w-0 flex-1 relative">
-              {leftActive === 'office' ? <MeetingRoom /> : rightContent}
+              {leftActive === 'office' ? <Office /> : rightContent}
               {leftActive === 'providers' && (
                 <div data-id="providers-right-mount" ref={setProvidersRightMount} />
               )}

--- a/app/src/components/office/AgentCanvas.tsx
+++ b/app/src/components/office/AgentCanvas.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useRef, useState } from 'react';
+import { Plus, Minus, Maximize2, CircleDot, Loader2, CheckCircle2, Crown } from 'lucide-react';
+
+/*
+ * AgentCanvas — 「办公室」活体看板画布原型（data-id="agent-canvas"）。
+ *
+ * 纯 UI 原型，mock 实时流（先不接接口）。每个 agent = 一张轻卡（LiteAgentCard），
+ * 只显示 thinking + text 工作状态（不渲染 tool_result）；想看谁点谁放大。
+ * 画布支持拖拽平移 / 滚轮缩放 / 拖动单卡 / 点击聚焦。w-10001 = 总控中心节点。
+ *
+ * 接接口时：每张卡轮询该 agent 的 current-reply（只取 type∈{thinking,text}），
+ * 离屏/未聚焦降频走批量 digest（见 plan）。这里用 setInterval 模拟流。
+ */
+
+type LineType = 'thinking' | 'text';
+interface Line { t: LineType; s: string }
+type Status = 'idle' | 'working' | 'done';
+
+interface CanvasAgent {
+  id: string;
+  name: string;
+  role: string;
+  emoji: string;
+  accent: string;          // tailwind 颜色名片段，如 'sky'
+  x: number;
+  y: number;
+  status: Status;
+  script: Line[];
+  shown: number;           // 已揭示的行数（mock 流）
+  controller?: boolean;
+}
+
+const A = (id: string, name: string, role: string, emoji: string, accent: string, x: number, y: number, status: Status, script: Line[], controller = false): CanvasAgent =>
+  ({ id, name, role, emoji, accent, x, y, status, script, shown: status === 'working' ? 0 : script.length, controller });
+
+const INIT: CanvasAgent[] = [
+  A('w-10001', '总控 Opus', '总负责人', '🏢', 'amber', 380, 40, 'idle', [
+    { t: 'text', s: '当前 3 个任务在跑，等 work done 回报。' },
+    { t: 'thinking', s: '前端原型先行，QA 待命，安全并行审。' },
+    { t: 'text', s: '派给 Finn：画布原型；派给 Aria：拆任务卡。' },
+  ], true),
+  A('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 60, 240, 'working', [
+    { t: 'thinking', s: '把"画布"需求拆成 3 张卡：数据层 / 渲染层 / 画布层。' },
+    { t: 'text', s: '定义 LiteAgentCard props + digest 端点契约。' },
+    { t: 'thinking', s: 'tool_result 不传，payload 能小一个数量级。' },
+    { t: 'text', s: '接口写进 docs，交给 Finn 实现。' },
+    { t: 'text', s: '✅ 完成：技术任务卡 + 接口契约。' },
+  ]),
+  A('w-10011', '前端 Finn', 'dev-junior', '🎨', 'violet', 380, 360, 'working', [
+    { t: 'thinking', s: '先看现有 MeetingRoom 的布局约定，复用 normalize。' },
+    { t: 'text', s: '新建 AgentCanvas.tsx，搭 pan/zoom 容器。' },
+    { t: 'thinking', s: '卡片用 absolute + transform，避免重排。' },
+    { t: 'text', s: 'LiteAgentCard 过滤 type∈{thinking,text}。' },
+    { t: 'thinking', s: '离屏卡片要降频轮询 —— 先留 TODO。' },
+    { t: 'text', s: '✅ 完成：画布骨架 + 卡片实时渲染。' },
+  ]),
+  A('w-10012', '测试 Quinn', 'qa', '🧪', 'emerald', 720, 300, 'working', [
+    { t: 'thinking', s: '核对验收标准：N 卡同屏不卡 = 命门。' },
+    { t: 'text', s: '跑 20 卡压力，盯帧率与内存。' },
+    { t: 'thinking', s: 'thinking 太长会撑爆卡片，得截断。' },
+    { t: 'text', s: 'FAIL：离屏卡片仍在 700ms 轮询，需门控。' },
+  ]),
+  A('w-10013', '运维 Ops', 'ops', '🚀', 'orange', 80, 460, 'idle', [
+    { t: 'text', s: '待构建产物，准备部署到 :8008。' },
+  ]),
+  A('w-10014', '安全 Sage', 'reviewer', '🛡️', 'rose', 720, 80, 'working', [
+    { t: 'thinking', s: '扫一遍有没有把 token 渲进卡片。' },
+    { t: 'text', s: 'text+thinking 不含工具入参，攻击面更小。' },
+    { t: 'text', s: '✅ 完成：安全结论 PASS。' },
+  ]),
+];
+
+const ACCENT: Record<string, { ring: string; chip: string; dot: string }> = {
+  amber:   { ring: 'border-amber-400/40',   chip: 'bg-amber-500/15 text-amber-200',   dot: 'text-amber-400' },
+  sky:     { ring: 'border-sky-400/30',     chip: 'bg-sky-500/15 text-sky-300',       dot: 'text-sky-400' },
+  violet:  { ring: 'border-violet-400/30',  chip: 'bg-violet-500/15 text-violet-300', dot: 'text-violet-400' },
+  emerald: { ring: 'border-emerald-400/30', chip: 'bg-emerald-500/15 text-emerald-300', dot: 'text-emerald-400' },
+  orange:  { ring: 'border-orange-400/30',  chip: 'bg-orange-500/15 text-orange-300', dot: 'text-orange-400' },
+  rose:    { ring: 'border-rose-400/30',    chip: 'bg-rose-500/15 text-rose-300',     dot: 'text-rose-400' },
+};
+
+const Z_MIN = 0.4, Z_MAX = 1.8;
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+export default function AgentCanvas() {
+  const [agents, setAgents] = useState<CanvasAgent[]>(INIT);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+
+  const dragRef = useRef<null | {
+    kind: 'pan' | 'card'; id?: string;
+    startX: number; startY: number; origX: number; origY: number; moved: boolean;
+  }>(null);
+
+  // mock 实时流：每 ~1.2s 给 working 的 agent 揭示下一行；揭完转 done；偶尔重新开工保持"活"。
+  useEffect(() => {
+    const t = window.setInterval(() => {
+      setAgents((prev) => prev.map((a) => {
+        if (a.controller) return a;
+        if (a.status === 'working') {
+          if (a.shown < a.script.length) return { ...a, shown: a.shown + 1 };
+          return { ...a, status: 'done' };
+        }
+        if (a.status === 'done' && Math.random() < 0.12) {
+          return { ...a, status: 'working', shown: 0 };
+        }
+        return a;
+      }));
+    }, 1200);
+    return () => window.clearInterval(t);
+  }, []);
+
+  // 指针：背景拖=平移，卡头拖=移卡
+  const onPointerDownBg = (e: React.PointerEvent) => {
+    dragRef.current = { kind: 'pan', startX: e.clientX, startY: e.clientY, origX: pan.x, origY: pan.y, moved: false };
+  };
+  const onPointerDownCard = (e: React.PointerEvent, a: CanvasAgent) => {
+    e.stopPropagation();
+    dragRef.current = { kind: 'card', id: a.id, startX: e.clientX, startY: e.clientY, origX: a.x, origY: a.y, moved: false };
+  };
+  useEffect(() => {
+    const move = (e: PointerEvent) => {
+      const d = dragRef.current;
+      if (!d) return;
+      const dx = e.clientX - d.startX, dy = e.clientY - d.startY;
+      if (Math.abs(dx) > 3 || Math.abs(dy) > 3) d.moved = true;
+      if (d.kind === 'pan') setPan({ x: d.origX + dx, y: d.origY + dy });
+      else setAgents((prev) => prev.map((a) => a.id === d.id ? { ...a, x: d.origX + dx / zoom, y: d.origY + dy / zoom } : a));
+    };
+    const up = () => {
+      const d = dragRef.current;
+      if (d && d.kind === 'card' && !d.moved && d.id) setFocusedId((f) => (f === d.id ? null : d.id!));
+      if (d && d.kind === 'pan' && !d.moved) setFocusedId(null);
+      dragRef.current = null;
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+    return () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+  }, [zoom]);
+
+  const onWheel = (e: React.WheelEvent) => {
+    e.preventDefault();
+    const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+    const next = clamp(zoom * factor, Z_MIN, Z_MAX);
+    // 以指针为中心缩放
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
+    setPan((p) => ({ x: cx - (cx - p.x) * (next / zoom), y: cy - (cy - p.y) * (next / zoom) }));
+    setZoom(next);
+  };
+
+  const zoomBy = (f: number) => setZoom((z) => clamp(z * f, Z_MIN, Z_MAX));
+  const reset = () => { setPan({ x: 0, y: 0 }); setZoom(1); setFocusedId(null); };
+
+  const workingCount = agents.filter((a) => !a.controller && a.status === 'working').length;
+  const doneCount = agents.filter((a) => !a.controller && a.status === 'done').length;
+
+  return (
+    <div data-id="agent-canvas" className="absolute inset-0 overflow-hidden bg-[#080808] select-none"
+      style={{ backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px)', backgroundSize: `${24 * zoom}px ${24 * zoom}px`, backgroundPosition: `${pan.x}px ${pan.y}px` }}
+      onPointerDown={onPointerDownBg}
+      onWheel={onWheel}
+    >
+      {/* 平移/缩放层 */}
+      <div data-id="agent-canvas-layer" className="absolute left-0 top-0 origin-top-left"
+        style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})` }}
+      >
+        {agents.map((a) => (
+          <LiteAgentCard key={a.id} agent={a} focused={focusedId === a.id}
+            onPointerDownHeader={(e) => onPointerDownCard(e, a)} />
+        ))}
+      </div>
+
+      {/* HUD：统计 */}
+      <div data-id="agent-canvas-stats" className="pointer-events-none absolute left-3 top-3 flex items-center gap-2 text-[11px] text-zinc-500">
+        <span className="rounded-md bg-white/[0.04] px-2 py-1">{agents.length - 1} 名成员</span>
+        <span className="rounded-md bg-amber-500/10 px-2 py-1 text-amber-300/80">工作中 {workingCount}</span>
+        <span className="rounded-md bg-emerald-500/10 px-2 py-1 text-emerald-300/80">完成 {doneCount}</span>
+        <span className="rounded-md bg-white/[0.03] px-2 py-1 text-zinc-600">只显示 thinking + text · tool 结果不拉</span>
+      </div>
+
+      {/* 缩放控件 */}
+      <div data-id="agent-canvas-controls" className="absolute bottom-4 right-4 flex flex-col gap-1.5">
+        <button data-id="agent-canvas-zoom-in" onClick={() => zoomBy(1.15)} className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Plus className="h-4 w-4" /></button>
+        <button data-id="agent-canvas-zoom-out" onClick={() => zoomBy(1 / 1.15)} className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Minus className="h-4 w-4" /></button>
+        <button data-id="agent-canvas-reset" onClick={reset} title="复位" className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Maximize2 className="h-4 w-4" /></button>
+        <div className="text-center text-[10px] text-zinc-600">{Math.round(zoom * 100)}%</div>
+      </div>
+    </div>
+  );
+}
+
+const STATUS_META: Record<Status, { label: string; cls: string }> = {
+  idle:    { label: '空闲',   cls: 'text-zinc-500' },
+  working: { label: '工作中', cls: 'text-amber-300' },
+  done:    { label: '完成',   cls: 'text-emerald-300' },
+};
+
+function LiteAgentCard({ agent, focused, onPointerDownHeader }: {
+  agent: CanvasAgent;
+  focused: boolean;
+  onPointerDownHeader: (e: React.PointerEvent) => void;
+}) {
+  const acc = ACCENT[agent.accent] ?? ACCENT.sky;
+  const lines = agent.script.slice(0, agent.shown);
+  const maxLines = focused ? 16 : 5;
+  const visible = lines.slice(-maxLines);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const st = STATUS_META[agent.status];
+
+  useEffect(() => {
+    const n = bodyRef.current;
+    if (n) n.scrollTop = n.scrollHeight;
+  }, [agent.shown, focused]);
+
+  const w = focused ? 380 : 248;
+  const h = focused ? 320 : 168;
+
+  return (
+    <div
+      data-id={`agent-canvas-card-${agent.id}`}
+      className={`absolute flex flex-col overflow-hidden rounded-xl border bg-[#0e0e0e] shadow-xl transition-[width,height] duration-150 ${focused ? 'border-white/25 ring-1 ring-white/10' : acc.ring} ${agent.controller ? 'ring-1 ring-amber-400/30' : ''}`}
+      style={{ left: agent.x, top: agent.y, width: w, height: h, zIndex: focused ? 50 : agent.controller ? 20 : 10 }}
+    >
+      {/* header（拖拽手柄） */}
+      <div
+        data-id={`agent-canvas-card-header-${agent.id}`}
+        onPointerDown={onPointerDownHeader}
+        className="flex cursor-grab items-center gap-2 border-b border-white/[0.06] bg-white/[0.02] px-2.5 py-2 active:cursor-grabbing"
+      >
+        <span className="grid h-7 w-7 shrink-0 place-items-center rounded-lg bg-white/[0.05] text-base">{agent.emoji}</span>
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-1">
+            {agent.controller && <Crown className="h-3 w-3 text-amber-400" />}
+            <span className="truncate text-[12.5px] font-medium text-zinc-200">{agent.name}</span>
+          </span>
+          <span className="font-mono text-[10.5px] text-zinc-500">{agent.id} · {agent.role}</span>
+        </span>
+        <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] ${acc.chip}`}>
+          {agent.status === 'working' ? <Loader2 className="h-3 w-3 animate-spin" /> :
+           agent.status === 'done' ? <CheckCircle2 className="h-3 w-3" /> :
+           <CircleDot className={`h-3 w-3 ${acc.dot}`} />}
+          {st.label}
+        </span>
+      </div>
+
+      {/* body：thinking + text 实时流 */}
+      <div ref={bodyRef} data-id={`agent-canvas-card-body-${agent.id}`} className="flex-1 space-y-1.5 overflow-auto px-2.5 py-2">
+        {visible.length === 0 ? (
+          <div className="text-[11.5px] text-zinc-600">{agent.controller ? '调度中…' : '待派活…'}</div>
+        ) : visible.map((ln, i) => (
+          ln.t === 'thinking' ? (
+            <div key={i} className="border-l-2 border-amber-300/25 pl-2 text-[11.5px] leading-relaxed text-amber-50/55">{ln.s}</div>
+          ) : (
+            <div key={i} className="text-[11.5px] leading-relaxed text-zinc-300">{ln.s}</div>
+          )
+        ))}
+      </div>
+
+      {agent.status === 'done' && (
+        <div className="shrink-0 border-t border-emerald-500/15 bg-emerald-500/[0.06] px-2.5 py-1 text-[10.5px] text-emerald-300/90">✅ work done · 等总控验收</div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, CircleDot, MessageSquare,
-  Plus, Minus, Maximize2,
+  Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, MessageSquare,
+  Plus, Minus, Maximize2, Crown, Inbox,
 } from 'lucide-react';
 
 /*
  * Office — 「办公室」（data-id="office"）。
- * 左栏：命令对话（上=history，下=prompt，自动 @ 选中的 worker，可广播）。
- * 右侧：可平移/缩放的画布，每个 worker = 一张可拖动 + 可缩放的 chat window，
- *       只显示 thinking + text（不拉 tool 结果）；头像 = agent avatar。
+ * 左栏：指挥台（总控对话，上=history，下=prompt，自动 @ 选中 worker，可广播）。
+ * 右侧：可平移/缩放画布，每个 worker = 可拖动+可缩放的 chat window，
+ *       只显示 thinking + text（不拉 tool 结果），头像 = agent avatar + 状态环。
  * 纯 UI 原型，mock 实时流（先不接接口）。
  */
 
@@ -18,81 +18,94 @@ type Status = 'idle' | 'working' | 'done';
 
 interface Worker {
   id: string; name: string; role: string; emoji: string; accent: string;
-  status: Status; script: Line[]; shown: number;
-  x: number; y: number; w: number; h: number;   // 画布坐标 + 尺寸
+  status: Status; script: Line[]; shown: number; startedAt: number;
+  x: number; y: number; w: number; h: number;
 }
 
-type ChatKind = 'you' | 'dispatch' | 'broadcast' | 'done' | 'note';
+type ChatKind = 'dispatch' | 'broadcast' | 'done' | 'note';
 interface ChatMsg { id: number; kind: ChatKind; from?: string; to?: string; text: string; ts: string }
 
 const SELF = 'w-10001';
-const MIN_W = 220, MIN_H = 150;
+const MIN_W = 240, MIN_H = 168;
 
 const W = (id: string, name: string, role: string, emoji: string, accent: string, status: Status, x: number, y: number, script: Line[]): Worker =>
-  ({ id, name, role, emoji, accent, status, script, shown: status === 'working' ? 0 : script.length, x, y, w: 300, h: 220 });
+  ({ id, name, role, emoji, accent, status, script, shown: status === 'working' ? 0 : script.length, startedAt: 0, x, y, w: 312, h: 232 });
 
 const INIT_WORKERS: Worker[] = [
-  W('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 'working', 40, 40, [
+  W('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 'working', 36, 32, [
     { t: 'thinking', s: '把"画布"拆成 3 张卡：数据层 / 渲染层 / 画布层。' },
     { t: 'text', s: '定义 LiteAgentCard props + digest 端点契约。' },
     { t: 'thinking', s: 'tool_result 不传，payload 小一个数量级。' },
     { t: 'text', s: '接口写进 docs，交给 Finn。' },
     { t: 'text', s: '✅ 完成：技术任务卡 + 接口契约。' },
   ]),
-  W('w-10011', '前端 Finn', 'dev-junior', '🎨', 'violet', 'working', 372, 40, [
+  W('w-10011', '前端 Finn', 'dev-junior', '🎨', 'violet', 'working', 384, 32, [
     { t: 'thinking', s: '复用 normalize，搭可拖拽/缩放的 window。' },
-    { t: 'text', s: '左栏命令对话 + 右栏画布。' },
+    { t: 'text', s: '左栏指挥台 + 右栏画布。' },
     { t: 'thinking', s: '选中 window → prompt 自动 @ 它。' },
-    { t: 'text', s: '加 drag handle + resize 角。' },
+    { t: 'text', s: '加 drag handle + resize 抓手。' },
     { t: 'text', s: '✅ 完成：可拖拽缩放的办公室画布。' },
   ]),
-  W('w-10012', '测试 Quinn', 'qa', '🧪', 'emerald', 'working', 704, 40, [
+  W('w-10012', '测试 Quinn', 'qa', '🧪', 'emerald', 'working', 732, 32, [
     { t: 'thinking', s: '核对验收标准：N window 同屏不卡。' },
     { t: 'text', s: '跑 20 window 压力，盯帧率。' },
     { t: 'thinking', s: 'thinking 太长要截断。' },
     { t: 'text', s: 'FAIL：离屏 window 仍在轮询，需门控。' },
   ]),
-  W('w-10013', '运维 Ops', 'ops', '🚀', 'orange', 'idle', 206, 292, [
+  W('w-10013', '运维 Ops', 'ops', '🚀', 'amber', 'idle', 210, 296, [
     { t: 'text', s: '待构建产物，准备部署。' },
   ]),
-  W('w-10014', '安全 Sage', 'reviewer', '🛡️', 'rose', 'working', 538, 292, [
+  W('w-10014', '安全 Sage', 'reviewer', '🛡️', 'rose', 'working', 558, 296, [
     { t: 'thinking', s: '扫一遍有没有把 token 渲进 window。' },
     { t: 'text', s: 'text+thinking 不含工具入参，攻击面更小。' },
     { t: 'text', s: '✅ 完成：安全结论 PASS。' },
   ]),
 ];
 
-const ACCENT: Record<string, { grad: string; ring: string; chip: string; dot: string }> = {
-  sky:     { grad: 'from-sky-500/40 to-sky-700/20',         ring: 'ring-sky-400/40',     chip: 'bg-sky-500/15 text-sky-300',       dot: 'text-sky-400' },
-  violet:  { grad: 'from-violet-500/40 to-violet-700/20',   ring: 'ring-violet-400/40',  chip: 'bg-violet-500/15 text-violet-300', dot: 'text-violet-400' },
-  emerald: { grad: 'from-emerald-500/40 to-emerald-700/20', ring: 'ring-emerald-400/40', chip: 'bg-emerald-500/15 text-emerald-300', dot: 'text-emerald-400' },
-  orange:  { grad: 'from-orange-500/40 to-orange-700/20',   ring: 'ring-orange-400/40',  chip: 'bg-orange-500/15 text-orange-300', dot: 'text-orange-400' },
-  rose:    { grad: 'from-rose-500/40 to-rose-700/20',       ring: 'ring-rose-400/40',    chip: 'bg-rose-500/15 text-rose-300',     dot: 'text-rose-400' },
+const ACCENT: Record<string, { grad: string; ring: string; chip: string; bar: string; ping: string }> = {
+  sky:     { grad: 'from-sky-500/40 to-sky-700/15',         ring: 'ring-sky-400/50',     chip: 'text-sky-300',     bar: 'bg-sky-400/50',     ping: 'ring-sky-400/60' },
+  violet:  { grad: 'from-violet-500/40 to-violet-700/15',   ring: 'ring-violet-400/50',  chip: 'text-violet-300',  bar: 'bg-violet-400/50',  ping: 'ring-violet-400/60' },
+  emerald: { grad: 'from-emerald-500/40 to-emerald-700/15', ring: 'ring-emerald-400/50', chip: 'text-emerald-300', bar: 'bg-emerald-400/50', ping: 'ring-emerald-400/60' },
+  amber:   { grad: 'from-amber-500/40 to-amber-700/15',     ring: 'ring-amber-400/50',   chip: 'text-amber-300',   bar: 'bg-amber-400/50',   ping: 'ring-amber-400/60' },
+  rose:    { grad: 'from-rose-500/40 to-rose-700/15',       ring: 'ring-rose-400/50',    chip: 'text-rose-300',    bar: 'bg-rose-400/50',    ping: 'ring-rose-400/60' },
 };
-const STATUS_META: Record<Status, { label: string }> = { idle: { label: '空闲' }, working: { label: '工作中' }, done: { label: '完成' } };
 const Z_MIN = 0.4, Z_MAX = 1.8;
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+const hhmm = (ms: number) => { const d = new Date(ms); const p = (n: number) => String(n).padStart(2, '0'); return `${p(d.getHours())}:${p(d.getMinutes())}`; };
+const elapsed = (from: number, now: number) => {
+  if (!from) return '';
+  const s = Math.max(0, Math.floor((now - from) / 1000));
+  return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m${p2(s % 60)}s`;
+};
+const p2 = (n: number) => String(n).padStart(2, '0');
 
-function nowStamp(): string {
-  const d = new Date(); const p = (n: number) => String(n).padStart(2, '0');
-  return `${p(d.getHours())}:${p(d.getMinutes())}`;
-}
-
-function Avatar({ emoji, accent, size = 28 }: { emoji: string; accent: string; size?: number }) {
+/* ── avatar：emoji + 状态环（working 脉冲 / done 绿环 / idle 灰）── */
+function Avatar({ emoji, accent, size = 30, status }: { emoji: string; accent: string; size?: number; status?: Status }) {
   const acc = ACCENT[accent] ?? ACCENT.sky;
-  return <span className={`grid shrink-0 place-items-center rounded-full bg-gradient-to-br ${acc.grad} ring-1 ring-white/10`} style={{ width: size, height: size, fontSize: size * 0.5 }}>{emoji}</span>;
+  const ring = status === 'done' ? 'ring-2 ring-emerald-400/70' : status === 'working' ? `ring-2 ${acc.ring}` : 'ring-1 ring-white/10';
+  return (
+    <span className="relative inline-grid shrink-0 place-items-center" style={{ width: size, height: size }}>
+      {status === 'working' && <span className={`absolute inset-0 rounded-full ring-2 ${acc.ping} animate-ping opacity-40`} />}
+      <span className={`grid h-full w-full place-items-center rounded-full bg-gradient-to-br ${acc.grad} ${ring}`} style={{ fontSize: size * 0.5 }}>{emoji}</span>
+    </span>
+  );
 }
 
 export default function Office() {
-  const [workers, setWorkers] = useState<Worker[]>(INIT_WORKERS);
+  const [workers, setWorkers] = useState<Worker[]>(() => {
+    const t0 = Date.now();
+    return INIT_WORKERS.map((w) => (w.status === 'working' ? { ...w, startedAt: t0 } : w));
+  });
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [hoverId, setHoverId] = useState<string | null>(null);
   const [mode, setMode] = useState<'single' | 'broadcast'>('single');
   const [text, setText] = useState('');
   const [mentionOpen, setMentionOpen] = useState(false);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [zoom, setZoom] = useState(1);
+  const [now, setNow] = useState(() => Date.now());
   const [chat, setChat] = useState<ChatMsg[]>([
-    { id: 1, kind: 'note', text: '办公室就绪。拖动卡片标题可移动、拖右下角可缩放、拖空白处平移画布、滚轮缩放。点某 worker 自动 @ 派任务，或切广播。', ts: nowStamp() },
+    { id: 1, kind: 'note', text: '拖标题移动卡片、拖右下角缩放、空白拖拽平移、滚轮缩放。点 worker 自动 @ 派任务，或切广播。', ts: hhmm(Date.now()) },
   ]);
   const seq = useRef(2);
   const chatRef = useRef<HTMLDivElement>(null);
@@ -101,39 +114,31 @@ export default function Office() {
 
   const byId = useMemo(() => Object.fromEntries(workers.map((w) => [w.id, w])), [workers]);
   const target = selectedId ? byId[selectedId] : null;
+  const online = workers.filter((w) => w.status !== 'idle').length;
 
+  // mock 实时流 + 计时
   useEffect(() => {
     const t = window.setInterval(() => {
+      const ts = Date.now();
       setWorkers((prev) => prev.map((w) => {
         if (w.status === 'working') return w.shown < w.script.length ? { ...w, shown: w.shown + 1 } : { ...w, status: 'done' };
-        if (w.status === 'done' && Math.random() < 0.1) return { ...w, status: 'working', shown: 0 };
+        if (w.status === 'done' && Math.random() < 0.08) return { ...w, status: 'working', shown: 0, startedAt: ts };
         return w;
       }));
     }, 1200);
-    return () => window.clearInterval(t);
+    const c = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => { window.clearInterval(t); window.clearInterval(c); };
   }, []);
 
   useEffect(() => { const n = chatRef.current; if (n) n.scrollTop = n.scrollHeight; }, [chat]);
 
-  const push = (m: Omit<ChatMsg, 'id' | 'ts'>) => setChat((c) => [...c, { id: seq.current++, ts: nowStamp(), ...m }]);
+  const push = (m: Omit<ChatMsg, 'id' | 'ts'>) => setChat((c) => [...c, { id: seq.current++, ts: hhmm(Date.now()), ...m }]);
 
-  const selectWorker = (w?: Worker) => {
-    if (!w) return;
-    setSelectedId(w.id); setMode('single'); setMentionOpen(false); inputRef.current?.focus();
-  };
+  const selectWorker = (w?: Worker) => { if (!w) return; setSelectedId(w.id); setMode('single'); setMentionOpen(false); inputRef.current?.focus(); };
 
-  // 画布交互
-  const onPointerDownBg = (e: React.PointerEvent) => {
-    dragRef.current = { kind: 'pan', sx: e.clientX, sy: e.clientY, ox: pan.x, oy: pan.y, ow: 0, oh: 0, moved: false };
-  };
-  const startMove = (e: React.PointerEvent, w: Worker) => {
-    e.stopPropagation();
-    dragRef.current = { kind: 'move', id: w.id, sx: e.clientX, sy: e.clientY, ox: w.x, oy: w.y, ow: w.w, oh: w.h, moved: false };
-  };
-  const startResize = (e: React.PointerEvent, w: Worker) => {
-    e.stopPropagation();
-    dragRef.current = { kind: 'resize', id: w.id, sx: e.clientX, sy: e.clientY, ox: w.x, oy: w.y, ow: w.w, oh: w.h, moved: false };
-  };
+  const onPointerDownBg = (e: React.PointerEvent) => { dragRef.current = { kind: 'pan', sx: e.clientX, sy: e.clientY, ox: pan.x, oy: pan.y, ow: 0, oh: 0, moved: false }; };
+  const startMove = (e: React.PointerEvent, w: Worker) => { e.stopPropagation(); dragRef.current = { kind: 'move', id: w.id, sx: e.clientX, sy: e.clientY, ox: w.x, oy: w.y, ow: w.w, oh: w.h, moved: false }; };
+  const startResize = (e: React.PointerEvent, w: Worker) => { e.stopPropagation(); dragRef.current = { kind: 'resize', id: w.id, sx: e.clientX, sy: e.clientY, ox: w.x, oy: w.y, ow: w.w, oh: w.h, moved: false }; };
   useEffect(() => {
     const move = (e: PointerEvent) => {
       const d = dragRef.current; if (!d) return;
@@ -148,8 +153,7 @@ export default function Office() {
       if (d && !d.moved) { if (d.kind === 'move' && d.id) selectWorker(byId[d.id]); else if (d.kind === 'pan') setSelectedId(null); }
       dragRef.current = null;
     };
-    window.addEventListener('pointermove', move);
-    window.addEventListener('pointerup', up);
+    window.addEventListener('pointermove', move); window.addEventListener('pointerup', up);
     return () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
   }, [zoom, byId]);
 
@@ -167,16 +171,14 @@ export default function Office() {
       setWorkers((prev) => prev.map((w) => (w.id === who ? { ...w, status: 'done' } : w)));
     }, 2600);
   };
-
   const send = () => {
     const body = text.trim(); if (!body) return;
     if (mode === 'broadcast') { push({ kind: 'broadcast', text: body }); setText(''); return; }
     if (!target) return;
     push({ kind: 'dispatch', to: target.id, text: body });
-    setWorkers((prev) => prev.map((w) => (w.id === target.id ? { ...w, status: 'working', shown: 0 } : w)));
+    setWorkers((prev) => prev.map((w) => (w.id === target.id ? { ...w, status: 'working', shown: 0, startedAt: Date.now() } : w)));
     setText(''); simulateDone(target.id);
   };
-
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } };
   const onChange = (v: string) => { setText(v); if (mode === 'single') setMentionOpen(/(^|\s)@$/.test(v)); };
   const pickMention = (w: Worker) => { setSelectedId(w.id); setMode('single'); setText((v) => v.replace(/@$/, '')); setMentionOpen(false); inputRef.current?.focus(); };
@@ -184,67 +186,79 @@ export default function Office() {
 
   return (
     <div data-id="office" className="absolute inset-0 flex bg-[#0A0A0A] text-zinc-300">
-      {/* 左栏：命令对话 */}
-      <aside data-id="office-command" className="flex w-[336px] min-w-[336px] shrink-0 flex-col border-r border-[var(--vsc-border)] bg-[#0c0c0c]">
-        <div className="flex h-12 shrink-0 items-center gap-2 border-b border-[var(--vsc-border)] px-4">
-          <Building2 className="h-4 w-4 text-sky-400" />
-          <span className="text-sm font-semibold text-zinc-100">办公室</span>
-          <span className="text-[11px] text-zinc-500">· 总控 {SELF}</span>
+      {/* 左栏：指挥台 */}
+      <aside data-id="office-command" className="flex w-[340px] min-w-[340px] shrink-0 flex-col border-r border-white/[0.06] bg-[#0b0b0c]">
+        <div className="flex h-14 shrink-0 items-center gap-2.5 border-b border-white/[0.06] px-4">
+          <span className="relative">
+            <span className="grid h-8 w-8 place-items-center rounded-full bg-gradient-to-br from-amber-400/40 to-amber-600/15 text-base ring-1 ring-amber-300/30">🏢</span>
+            <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full bg-emerald-400 ring-2 ring-[#0b0b0c]" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-1 text-[13px] font-semibold text-zinc-100"><Crown className="h-3 w-3 text-amber-400" /> 办公室 · 总控</div>
+            <div className="font-mono text-[11px] text-zinc-500">{SELF} · 在线 {online}/{workers.length}</div>
+          </div>
         </div>
-        <div ref={chatRef} data-id="office-command-history" className="flex-1 space-y-2.5 overflow-auto px-3 py-3">
+
+        <div ref={chatRef} data-id="office-command-history" className="flex-1 space-y-3 overflow-auto px-3.5 py-3.5">
           {chat.map((m) => <CommandMsg key={m.id} m={m} byId={byId} />)}
         </div>
-        <div data-id="office-command-prompt" className="shrink-0 border-t border-[var(--vsc-border)] bg-[#0d0d0d] px-3 py-3">
+
+        <div data-id="office-command-prompt" className="shrink-0 border-t border-white/[0.06] bg-[#0d0d0e] px-3.5 py-3">
           <div className="relative">
-            <div data-id="office-mode" className="mb-2 inline-flex items-center gap-1 rounded-lg bg-white/[0.04] p-0.5 text-[12px]">
-              <button data-id="office-mode-single" onClick={() => setMode('single')} className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'single' ? 'bg-white/10 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}`}><MessageSquare className="h-3.5 w-3.5" /> 单聊</button>
-              <button data-id="office-mode-broadcast" onClick={() => { setMode('broadcast'); setMentionOpen(false); }} className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'broadcast' ? 'bg-amber-500/20 text-amber-200' : 'text-zinc-500 hover:text-zinc-300'}`}><Megaphone className="h-3.5 w-3.5" /> 广播</button>
+            <div data-id="office-mode" className="mb-2 inline-flex items-center gap-0.5 rounded-lg bg-white/[0.04] p-0.5 text-[12px]">
+              <button data-id="office-mode-single" onClick={() => setMode('single')} className={`inline-flex items-center gap-1 rounded-md px-2.5 py-1 transition-colors ${mode === 'single' ? 'bg-white/10 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}`}><MessageSquare className="h-3.5 w-3.5" /> 单聊</button>
+              <button data-id="office-mode-broadcast" onClick={() => { setMode('broadcast'); setMentionOpen(false); }} className={`inline-flex items-center gap-1 rounded-md px-2.5 py-1 transition-colors ${mode === 'broadcast' ? 'bg-amber-500/20 text-amber-200' : 'text-zinc-500 hover:text-zinc-300'}`}><Megaphone className="h-3.5 w-3.5" /> 广播</button>
             </div>
             {mentionOpen && mode === 'single' && (
-              <div data-id="office-mention" className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-xl border border-white/10 bg-[#141414] shadow-2xl">
+              <div data-id="office-mention" className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-xl border border-white/10 bg-[#16161a] shadow-2xl">
                 {workers.map((w) => (
-                  <button key={w.id} data-id={`office-mention-${w.id}`} onClick={() => pickMention(w)} className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-white/[0.06]">
-                    <Avatar emoji={w.emoji} accent={w.accent} size={22} /><span className="text-[13px] text-zinc-200">{w.name}</span><span className="ml-auto font-mono text-[11px] text-zinc-500">{w.id}</span>
+                  <button key={w.id} data-id={`office-mention-${w.id}`} onClick={() => pickMention(w)} className="flex w-full items-center gap-2.5 px-3 py-2 text-left hover:bg-white/[0.06]">
+                    <Avatar emoji={w.emoji} accent={w.accent} size={24} status={w.status} /><span className="text-[13px] text-zinc-200">{w.name}</span><span className="ml-auto font-mono text-[11px] text-zinc-500">{w.id}</span>
                   </button>
                 ))}
               </div>
             )}
-            <div data-id="office-target" className="mb-2 flex items-center gap-1.5">
+            <div data-id="office-target" className="mb-2 flex min-h-[26px] items-center gap-1.5">
               {mode === 'broadcast' ? (
                 <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-2.5 py-1 text-[12px] text-amber-200"><Megaphone className="h-3 w-3" /> 广播 · 全体（{workers.length}）</span>
               ) : target ? (
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-sky-500/15 py-1 pl-1.5 pr-1.5 text-[12px] text-sky-300"><Avatar emoji={target.emoji} accent={target.accent} size={18} /><span className="font-mono">{target.id}</span><button data-id="office-target-clear" onClick={() => setSelectedId(null)} className="rounded-full p-0.5 hover:bg-white/10"><X className="h-3 w-3" /></button></span>
-              ) : (<span className="text-[12px] text-zinc-600">点画布里的 worker，或 @ 选择</span>)}
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-white/[0.06] py-1 pl-1 pr-2 text-[12px] text-zinc-200"><Avatar emoji={target.emoji} accent={target.accent} size={20} status={target.status} /><span className="font-medium">{target.name}</span><span className="font-mono text-[11px] text-zinc-500">{target.id}</span><button data-id="office-target-clear" onClick={() => setSelectedId(null)} className="rounded-full p-0.5 text-zinc-500 hover:bg-white/10 hover:text-zinc-200"><X className="h-3 w-3" /></button></span>
+              ) : (<span className="text-[12px] text-zinc-600">点画布里的 worker，或输入 @ 选择</span>)}
             </div>
-            <div className="flex items-end gap-2 rounded-xl border border-white/10 bg-[#111] px-3 py-2 focus-within:border-white/20">
+            <div className="flex items-end gap-2 rounded-2xl border border-white/10 bg-[#121214] px-3 py-2.5 transition-colors focus-within:border-white/25">
               <textarea ref={inputRef} data-id="office-input" rows={1} value={text} onChange={(e) => onChange(e.target.value)} onKeyDown={onKeyDown}
-                placeholder={mode === 'broadcast' ? '向全体广播…（Enter）' : target ? `给 ${target.name} 派任务…（Enter）` : '@ 选择 worker…'}
+                placeholder={mode === 'broadcast' ? '向全体广播…（Enter）' : target ? `给 ${target.name} 派任务…（Enter 发送）` : '输入 @ 选择 worker…'}
                 className="max-h-40 min-h-[24px] flex-1 resize-none bg-transparent text-[13px] leading-6 text-zinc-200 outline-none placeholder:text-zinc-600" />
-              <button data-id="office-send" onClick={send} disabled={!canSend} className={`grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white transition-colors disabled:cursor-not-allowed disabled:bg-white/[0.06] disabled:text-zinc-600 ${mode === 'broadcast' ? 'bg-amber-500/90 hover:bg-amber-400' : 'bg-sky-500/90 hover:bg-sky-400'}`}>{mode === 'broadcast' ? <Megaphone className="h-4 w-4" /> : <Send className="h-4 w-4" />}</button>
+              <button data-id="office-send" onClick={send} disabled={!canSend} className={`grid h-8 w-8 shrink-0 place-items-center rounded-xl text-white transition-all disabled:cursor-not-allowed disabled:bg-white/[0.06] disabled:text-zinc-600 ${mode === 'broadcast' ? 'bg-amber-500 hover:bg-amber-400' : 'bg-sky-500 hover:bg-sky-400'} ${canSend ? 'shadow-lg' : ''}`}>{mode === 'broadcast' ? <Megaphone className="h-4 w-4" /> : <Send className="h-4 w-4" />}</button>
             </div>
           </div>
         </div>
       </aside>
 
-      {/* 右侧：可拖拽/缩放的画布 */}
-      <main data-id="office-canvas" className="relative min-w-0 flex-1 overflow-hidden bg-[#080808]"
-        style={{ backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px)', backgroundSize: `${24 * zoom}px ${24 * zoom}px`, backgroundPosition: `${pan.x}px ${pan.y}px` }}
+      {/* 右侧：画布 */}
+      <main data-id="office-canvas" className="relative min-w-0 flex-1 overflow-hidden bg-[#060608]"
+        style={{ backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.045) 1px, transparent 1px)', backgroundSize: `${26 * zoom}px ${26 * zoom}px`, backgroundPosition: `${pan.x}px ${pan.y}px` }}
         onPointerDown={onPointerDownBg} onWheel={onWheel}>
+        {/* 暗角增加纵深 */}
+        <div className="pointer-events-none absolute inset-0" style={{ boxShadow: 'inset 0 0 160px 40px rgba(0,0,0,0.55)' }} />
+
         <div data-id="office-canvas-layer" className="absolute left-0 top-0 origin-top-left" style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})` }}>
           {workers.map((w) => (
-            <WorkerWindow key={w.id} w={w} selected={selectedId === w.id}
+            <WorkerWindow key={w.id} w={w} now={now} selected={selectedId === w.id} hovered={hoverId === w.id}
+              onHover={(h) => setHoverId((cur) => (h ? w.id : cur === w.id ? null : cur))}
               onMoveStart={(e) => startMove(e, w)} onResizeStart={(e) => startResize(e, w)} />
           ))}
         </div>
 
-        <div data-id="office-canvas-stats" className="pointer-events-none absolute left-3 top-3 flex items-center gap-2 text-[11px] text-zinc-500">
-          <span className="rounded-md bg-white/[0.04] px-2 py-1">{workers.length} 个 worker</span>
-          <span className="rounded-md bg-white/[0.03] px-2 py-1 text-zinc-600">只显示 thinking + text · tool 结果不拉</span>
+        <div data-id="office-canvas-topbar" className="pointer-events-none absolute left-4 top-4 flex items-center gap-2 text-[11px]">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-black/40 px-2.5 py-1 text-zinc-300 backdrop-blur"><span className="h-1.5 w-1.5 rounded-full bg-emerald-400" /> 团队工作台 · 在线 {online}/{workers.length}</span>
+          <span className="rounded-full border border-white/[0.06] bg-black/30 px-2.5 py-1 text-zinc-600 backdrop-blur">仅 thinking + text · 不拉 tool 结果</span>
         </div>
+
         <div data-id="office-canvas-controls" className="absolute bottom-4 right-4 flex flex-col gap-1.5">
-          <button data-id="office-zoom-in" onClick={() => setZoom((z) => clamp(z * 1.15, Z_MIN, Z_MAX))} className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Plus className="h-4 w-4" /></button>
-          <button data-id="office-zoom-out" onClick={() => setZoom((z) => clamp(z / 1.15, Z_MIN, Z_MAX))} className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Minus className="h-4 w-4" /></button>
-          <button data-id="office-zoom-reset" onClick={() => { setPan({ x: 0, y: 0 }); setZoom(1); }} title="复位" className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Maximize2 className="h-4 w-4" /></button>
+          <button data-id="office-zoom-in" onClick={() => setZoom((z) => clamp(z * 1.15, Z_MIN, Z_MAX))} className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#16161a]/90 text-zinc-400 backdrop-blur transition-colors hover:text-zinc-100"><Plus className="h-4 w-4" /></button>
+          <button data-id="office-zoom-out" onClick={() => setZoom((z) => clamp(z / 1.15, Z_MIN, Z_MAX))} className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#16161a]/90 text-zinc-400 backdrop-blur transition-colors hover:text-zinc-100"><Minus className="h-4 w-4" /></button>
+          <button data-id="office-zoom-reset" onClick={() => { setPan({ x: 0, y: 0 }); setZoom(1); }} title="复位" className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#16161a]/90 text-zinc-400 backdrop-blur transition-colors hover:text-zinc-100"><Maximize2 className="h-4 w-4" /></button>
           <div className="text-center text-[10px] text-zinc-600">{Math.round(zoom * 100)}%</div>
         </div>
       </main>
@@ -253,61 +267,90 @@ export default function Office() {
 }
 
 function CommandMsg({ m, byId }: { m: ChatMsg; byId: Record<string, Worker> }) {
-  if (m.kind === 'note') return <div data-id={`office-msg-${m.id}`} className="text-center text-[11.5px] leading-relaxed text-zinc-600">{m.text}</div>;
+  if (m.kind === 'note') return <div data-id={`office-msg-${m.id}`} className="px-2 text-center text-[11.5px] leading-relaxed text-zinc-600">{m.text}</div>;
   if (m.kind === 'broadcast') return (
-    <div data-id={`office-msg-${m.id}`} className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-2.5 py-1.5 text-[12.5px] text-amber-50/90"><span className="mr-1 text-[11px] text-amber-300/80">📢 广播 · 全体</span><div className="whitespace-pre-wrap">{m.text}</div></div>
+    <div data-id={`office-msg-${m.id}`} className="overflow-hidden rounded-xl border border-amber-500/20 bg-amber-500/[0.06]">
+      <div className="flex items-center gap-1 border-b border-amber-500/15 px-2.5 py-1 text-[10.5px] text-amber-300/90"><Megaphone className="h-3 w-3" /> 广播 · 全体 <span className="ml-auto font-mono text-amber-300/50">{m.ts}</span></div>
+      <div className="px-2.5 py-1.5 text-[12.5px] leading-relaxed text-amber-50/90 whitespace-pre-wrap">{m.text}</div>
+    </div>
   );
   if (m.kind === 'dispatch') {
     const w = m.to ? byId[m.to] : null;
     return (
-      <div data-id={`office-msg-${m.id}`} className="flex flex-col items-end gap-0.5">
-        <div className="flex items-center gap-1 text-[11px] text-zinc-500"><AtSign className="h-3 w-3" /><span className="font-mono">{m.to}</span>{w && <span>{w.name}</span>}</div>
-        <div className="max-w-[88%] rounded-lg rounded-tr-sm bg-sky-500/15 px-2.5 py-1.5 text-[12.5px] text-sky-100 whitespace-pre-wrap">{m.text}</div>
+      <div data-id={`office-msg-${m.id}`} className="flex flex-col items-end gap-1">
+        <div className="flex items-center gap-1.5 text-[11px] text-zinc-500">派给 {w && <Avatar emoji={w.emoji} accent={w.accent} size={16} />}<span className="text-zinc-400">{w?.name ?? m.to}</span></div>
+        <div className="max-w-[86%] rounded-2xl rounded-tr-md bg-sky-500/90 px-3 py-1.5 text-[12.5px] leading-relaxed text-white shadow-sm whitespace-pre-wrap">{m.text}</div>
       </div>
     );
   }
   const w = m.from ? byId[m.from] : null;
   return (
-    <div data-id={`office-msg-${m.id}`} className="flex items-center gap-1.5">
-      {w && <Avatar emoji={w.emoji} accent={w.accent} size={20} />}
-      <span className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/10 px-2 py-1 text-[12px] text-emerald-300"><CheckCircle2 className="h-3.5 w-3.5" /> {m.text}</span>
-      <span className="ml-auto text-[10px] text-zinc-700">{m.ts}</span>
+    <div data-id={`office-msg-${m.id}`} className="flex items-center gap-2">
+      {w && <Avatar emoji={w.emoji} accent={w.accent} size={22} status="done" />}
+      <div className="min-w-0 flex-1">
+        <div className="text-[11px] text-zinc-500">{w?.name ?? m.from}</div>
+        <div className="inline-flex items-center gap-1 text-[12px] text-emerald-300"><CheckCircle2 className="h-3.5 w-3.5" /> {m.text} <span className="text-zinc-600">· 待验收</span></div>
+      </div>
+      <span className="self-start font-mono text-[10px] text-zinc-700">{m.ts}</span>
     </div>
   );
 }
 
-function WorkerWindow({ w, selected, onMoveStart, onResizeStart }: {
-  w: Worker; selected: boolean; onMoveStart: (e: React.PointerEvent) => void; onResizeStart: (e: React.PointerEvent) => void;
+function WorkerWindow({ w, now, selected, hovered, onHover, onMoveStart, onResizeStart }: {
+  w: Worker; now: number; selected: boolean; hovered: boolean;
+  onHover: (h: boolean) => void; onMoveStart: (e: React.PointerEvent) => void; onResizeStart: (e: React.PointerEvent) => void;
 }) {
   const acc = ACCENT[w.accent] ?? ACCENT.sky;
   const lines = w.script.slice(0, w.shown).slice(-12);
   const bodyRef = useRef<HTMLDivElement>(null);
   useEffect(() => { const n = bodyRef.current; if (n) n.scrollTop = n.scrollHeight; }, [w.shown]);
+  const done = w.status === 'done';
+  const working = w.status === 'working';
 
   return (
     <div data-id={`office-window-${w.id}`}
-      className={`absolute flex flex-col overflow-hidden rounded-xl border bg-[#0e0e0e] shadow-xl ${selected ? `ring-2 ${acc.ring} border-transparent` : 'border-white/[0.08]'}`}
-      style={{ left: w.x, top: w.y, width: w.w, height: w.h, zIndex: selected ? 50 : 10 }}>
-      <div data-id={`office-window-header-${w.id}`} onPointerDown={onMoveStart} className="flex shrink-0 cursor-grab items-center gap-2 border-b border-white/[0.06] bg-white/[0.02] px-3 py-2 active:cursor-grabbing">
-        <Avatar emoji={w.emoji} accent={w.accent} size={30} />
-        <span className="min-w-0 flex-1"><span className="block truncate text-[13px] font-medium text-zinc-200">{w.name}</span><span className="font-mono text-[10.5px] text-zinc-500">{w.id} · {w.role}</span></span>
-        <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] ${acc.chip}`}>
-          {w.status === 'working' ? <Loader2 className="h-3 w-3 animate-spin" /> : w.status === 'done' ? <CheckCircle2 className="h-3 w-3" /> : <CircleDot className={`h-3 w-3 ${acc.dot}`} />}
-          {STATUS_META[w.status].label}
+      onPointerEnter={() => onHover(true)} onPointerLeave={() => onHover(false)}
+      className={`absolute flex flex-col overflow-hidden rounded-2xl border bg-[#0e0e11] transition-[box-shadow,transform,border-color] duration-150
+        ${selected ? `ring-2 ${acc.ring} border-transparent -translate-y-0.5 shadow-2xl` : hovered ? 'border-white/15 shadow-2xl' : 'border-white/[0.07] shadow-xl'}`}
+      style={{ left: w.x, top: w.y, width: w.w, height: w.h, zIndex: selected ? 60 : hovered ? 40 : 10 }}>
+      {/* 角色色条 */}
+      <div className={`h-[3px] w-full ${done ? 'bg-emerald-400/60' : acc.bar}`} />
+      <div data-id={`office-window-header-${w.id}`} onPointerDown={onMoveStart}
+        className={`flex shrink-0 cursor-grab items-center gap-2.5 px-3 py-2.5 active:cursor-grabbing ${done ? 'bg-emerald-500/[0.05]' : 'bg-white/[0.015]'}`}>
+        <Avatar emoji={w.emoji} accent={w.accent} size={32} status={w.status} />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[13px] font-semibold text-zinc-100">{w.name}</span>
+          <span className="font-mono text-[10.5px] text-zinc-500">{w.id} · {w.role}</span>
         </span>
+        {done ? (
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10.5px] font-medium text-emerald-300"><CheckCircle2 className="h-3 w-3" /> 待验收</span>
+        ) : working ? (
+          <span className={`inline-flex items-center gap-1 text-[10.5px] ${acc.chip}`}><Loader2 className="h-3 w-3 animate-spin" /> {elapsed(w.startedAt, now)}</span>
+        ) : (
+          <span className="text-[10.5px] text-zinc-600">空闲</span>
+        )}
       </div>
-      <div ref={bodyRef} data-id={`office-window-body-${w.id}`} className="flex-1 space-y-1.5 overflow-auto px-3 py-2">
-        {lines.length === 0 ? <div className="text-[11.5px] text-zinc-600">待派活…</div> : lines.map((ln, i) => (
-          ln.t === 'thinking'
-            ? <div key={i} className="border-l-2 border-amber-300/25 pl-2 text-[11.5px] leading-relaxed text-amber-50/55">{ln.s}</div>
-            : <div key={i} className="text-[12px] leading-relaxed text-zinc-300">{ln.s}</div>
-        ))}
+      <div className="mx-3 h-px bg-white/[0.05]" />
+      <div ref={bodyRef} data-id={`office-window-body-${w.id}`} className="flex-1 space-y-2 overflow-auto px-3 py-2.5">
+        {lines.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-1 text-zinc-700"><Inbox className="h-5 w-5" /><span className="text-[11px]">等待派活</span></div>
+        ) : lines.map((ln, i) => {
+          const isLast = i === lines.length - 1;
+          return ln.t === 'thinking' ? (
+            <div key={i} className="border-l-2 border-amber-300/25 pl-2 text-[11.5px] italic leading-relaxed text-amber-50/50">
+              {ln.s}{isLast && working && <span className="ml-0.5 animate-pulse text-amber-200/70">▍</span>}
+            </div>
+          ) : (
+            <div key={i} className="text-[12px] leading-relaxed text-zinc-300">
+              {ln.s}{isLast && working && <span className="ml-0.5 animate-pulse text-zinc-400">▍</span>}
+            </div>
+          );
+        })}
       </div>
-      {w.status === 'done' && <div className="shrink-0 border-t border-emerald-500/15 bg-emerald-500/[0.06] px-3 py-1 text-[10.5px] text-emerald-300/90">✅ work done · 等总控验收</div>}
-      {/* resize 角 */}
+      {/* resize 抓手：悬停/选中才显露 */}
       <div data-id={`office-window-resize-${w.id}`} onPointerDown={onResizeStart}
-        className="absolute bottom-0 right-0 h-4 w-4 cursor-nwse-resize"
-        style={{ background: 'linear-gradient(135deg, transparent 50%, rgba(255,255,255,0.25) 50%)' }} />
+        className={`absolute bottom-1 right-1 h-3.5 w-3.5 cursor-nwse-resize rounded-sm transition-opacity ${hovered || selected ? 'opacity-100' : 'opacity-0'}`}
+        style={{ background: 'linear-gradient(135deg, transparent 45%, rgba(255,255,255,0.4) 45%, rgba(255,255,255,0.4) 55%, transparent 55%, transparent 70%, rgba(255,255,255,0.4) 70%, rgba(255,255,255,0.4) 80%, transparent 80%)' }} />
     </div>
   );
 }

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, CircleDot, MessageSquare,
+  Plus, Minus, Maximize2,
 } from 'lucide-react';
 
 /*
  * Office — 「办公室」（data-id="office"）。
  * 左栏：命令对话（上=history，下=prompt，自动 @ 选中的 worker，可广播）。
- * 右侧：所有 worker 的 chat window，整齐网格，只显示 thinking + text（不拉 tool 结果）。
- * 头像 = 各 agent 的 avatar。纯 UI 原型，mock 实时流（先不接接口）。
+ * 右侧：可平移/缩放的画布，每个 worker = 一张可拖动 + 可缩放的 chat window，
+ *       只显示 thinking + text（不拉 tool 结果）；头像 = agent avatar。
+ * 纯 UI 原型，mock 实时流（先不接接口）。
  */
 
 type LineType = 'thinking' | 'text';
@@ -15,49 +17,45 @@ interface Line { t: LineType; s: string }
 type Status = 'idle' | 'working' | 'done';
 
 interface Worker {
-  id: string;
-  name: string;
-  role: string;
-  emoji: string;       // avatar 占位（接接口后换成 agent 真实 avatar）
-  accent: string;
-  status: Status;
-  script: Line[];
-  shown: number;
+  id: string; name: string; role: string; emoji: string; accent: string;
+  status: Status; script: Line[]; shown: number;
+  x: number; y: number; w: number; h: number;   // 画布坐标 + 尺寸
 }
 
 type ChatKind = 'you' | 'dispatch' | 'broadcast' | 'done' | 'note';
 interface ChatMsg { id: number; kind: ChatKind; from?: string; to?: string; text: string; ts: string }
 
 const SELF = 'w-10001';
+const MIN_W = 220, MIN_H = 150;
 
-const W = (id: string, name: string, role: string, emoji: string, accent: string, status: Status, script: Line[]): Worker =>
-  ({ id, name, role, emoji, accent, status, script, shown: status === 'working' ? 0 : script.length });
+const W = (id: string, name: string, role: string, emoji: string, accent: string, status: Status, x: number, y: number, script: Line[]): Worker =>
+  ({ id, name, role, emoji, accent, status, script, shown: status === 'working' ? 0 : script.length, x, y, w: 300, h: 220 });
 
 const INIT_WORKERS: Worker[] = [
-  W('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 'working', [
+  W('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 'working', 40, 40, [
     { t: 'thinking', s: '把"画布"拆成 3 张卡：数据层 / 渲染层 / 画布层。' },
     { t: 'text', s: '定义 LiteAgentCard props + digest 端点契约。' },
     { t: 'thinking', s: 'tool_result 不传，payload 小一个数量级。' },
     { t: 'text', s: '接口写进 docs，交给 Finn。' },
     { t: 'text', s: '✅ 完成：技术任务卡 + 接口契约。' },
   ]),
-  W('w-10011', '前端 Finn', 'dev-junior', '🎨', 'violet', 'working', [
-    { t: 'thinking', s: '复用 normalize，搭 worker window 网格。' },
-    { t: 'text', s: '左栏命令对话 + 右栏 window grid。' },
+  W('w-10011', '前端 Finn', 'dev-junior', '🎨', 'violet', 'working', 372, 40, [
+    { t: 'thinking', s: '复用 normalize，搭可拖拽/缩放的 window。' },
+    { t: 'text', s: '左栏命令对话 + 右栏画布。' },
     { t: 'thinking', s: '选中 window → prompt 自动 @ 它。' },
-    { t: 'text', s: 'window 加宽、对齐网格。' },
-    { t: 'text', s: '✅ 完成：办公室双栏布局。' },
+    { t: 'text', s: '加 drag handle + resize 角。' },
+    { t: 'text', s: '✅ 完成：可拖拽缩放的办公室画布。' },
   ]),
-  W('w-10012', '测试 Quinn', 'qa', '🧪', 'emerald', 'working', [
+  W('w-10012', '测试 Quinn', 'qa', '🧪', 'emerald', 'working', 704, 40, [
     { t: 'thinking', s: '核对验收标准：N window 同屏不卡。' },
     { t: 'text', s: '跑 20 window 压力，盯帧率。' },
     { t: 'thinking', s: 'thinking 太长要截断。' },
     { t: 'text', s: 'FAIL：离屏 window 仍在轮询，需门控。' },
   ]),
-  W('w-10013', '运维 Ops', 'ops', '🚀', 'orange', 'idle', [
+  W('w-10013', '运维 Ops', 'ops', '🚀', 'orange', 'idle', 206, 292, [
     { t: 'text', s: '待构建产物，准备部署。' },
   ]),
-  W('w-10014', '安全 Sage', 'reviewer', '🛡️', 'rose', 'working', [
+  W('w-10014', '安全 Sage', 'reviewer', '🛡️', 'rose', 'working', 538, 292, [
     { t: 'thinking', s: '扫一遍有没有把 token 渲进 window。' },
     { t: 'text', s: 'text+thinking 不含工具入参，攻击面更小。' },
     { t: 'text', s: '✅ 完成：安全结论 PASS。' },
@@ -71,25 +69,18 @@ const ACCENT: Record<string, { grad: string; ring: string; chip: string; dot: st
   orange:  { grad: 'from-orange-500/40 to-orange-700/20',   ring: 'ring-orange-400/40',  chip: 'bg-orange-500/15 text-orange-300', dot: 'text-orange-400' },
   rose:    { grad: 'from-rose-500/40 to-rose-700/20',       ring: 'ring-rose-400/40',    chip: 'bg-rose-500/15 text-rose-300',     dot: 'text-rose-400' },
 };
-
-const STATUS_META: Record<Status, { label: string; cls: string }> = {
-  idle:    { label: '空闲',   cls: 'text-zinc-500' },
-  working: { label: '工作中', cls: 'text-amber-300' },
-  done:    { label: '完成',   cls: 'text-emerald-300' },
-};
+const STATUS_META: Record<Status, { label: string }> = { idle: { label: '空闲' }, working: { label: '工作中' }, done: { label: '完成' } };
+const Z_MIN = 0.4, Z_MAX = 1.8;
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 function nowStamp(): string {
-  const d = new Date();
-  const p = (n: number) => String(n).padStart(2, '0');
+  const d = new Date(); const p = (n: number) => String(n).padStart(2, '0');
   return `${p(d.getHours())}:${p(d.getMinutes())}`;
 }
 
 function Avatar({ emoji, accent, size = 28 }: { emoji: string; accent: string; size?: number }) {
   const acc = ACCENT[accent] ?? ACCENT.sky;
-  return (
-    <span className={`grid shrink-0 place-items-center rounded-full bg-gradient-to-br ${acc.grad} ring-1 ring-white/10`}
-      style={{ width: size, height: size, fontSize: size * 0.5 }}>{emoji}</span>
-  );
+  return <span className={`grid shrink-0 place-items-center rounded-full bg-gradient-to-br ${acc.grad} ring-1 ring-white/10`} style={{ width: size, height: size, fontSize: size * 0.5 }}>{emoji}</span>;
 }
 
 export default function Office() {
@@ -98,24 +89,23 @@ export default function Office() {
   const [mode, setMode] = useState<'single' | 'broadcast'>('single');
   const [text, setText] = useState('');
   const [mentionOpen, setMentionOpen] = useState(false);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
   const [chat, setChat] = useState<ChatMsg[]>([
-    { id: 1, kind: 'note', text: '办公室就绪。点右侧某个 worker 自动 @ 他派任务；或切广播对全体喊话。', ts: nowStamp() },
+    { id: 1, kind: 'note', text: '办公室就绪。拖动卡片标题可移动、拖右下角可缩放、拖空白处平移画布、滚轮缩放。点某 worker 自动 @ 派任务，或切广播。', ts: nowStamp() },
   ]);
   const seq = useRef(2);
   const chatRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const dragRef = useRef<null | { kind: 'pan' | 'move' | 'resize'; id?: string; sx: number; sy: number; ox: number; oy: number; ow: number; oh: number; moved: boolean }>(null);
 
   const byId = useMemo(() => Object.fromEntries(workers.map((w) => [w.id, w])), [workers]);
   const target = selectedId ? byId[selectedId] : null;
 
-  // mock 实时流
   useEffect(() => {
     const t = window.setInterval(() => {
       setWorkers((prev) => prev.map((w) => {
-        if (w.status === 'working') {
-          if (w.shown < w.script.length) return { ...w, shown: w.shown + 1 };
-          return { ...w, status: 'done' };
-        }
+        if (w.status === 'working') return w.shown < w.script.length ? { ...w, shown: w.shown + 1 } : { ...w, status: 'done' };
         if (w.status === 'done' && Math.random() < 0.1) return { ...w, status: 'working', shown: 0 };
         return w;
       }));
@@ -123,18 +113,52 @@ export default function Office() {
     return () => window.clearInterval(t);
   }, []);
 
-  useEffect(() => {
-    const n = chatRef.current;
-    if (n) n.scrollTop = n.scrollHeight;
-  }, [chat]);
+  useEffect(() => { const n = chatRef.current; if (n) n.scrollTop = n.scrollHeight; }, [chat]);
 
   const push = (m: Omit<ChatMsg, 'id' | 'ts'>) => setChat((c) => [...c, { id: seq.current++, ts: nowStamp(), ...m }]);
 
-  const selectWorker = (w: Worker) => {
-    setSelectedId(w.id);
-    setMode('single');
-    setMentionOpen(false);
-    inputRef.current?.focus();
+  const selectWorker = (w?: Worker) => {
+    if (!w) return;
+    setSelectedId(w.id); setMode('single'); setMentionOpen(false); inputRef.current?.focus();
+  };
+
+  // 画布交互
+  const onPointerDownBg = (e: React.PointerEvent) => {
+    dragRef.current = { kind: 'pan', sx: e.clientX, sy: e.clientY, ox: pan.x, oy: pan.y, ow: 0, oh: 0, moved: false };
+  };
+  const startMove = (e: React.PointerEvent, w: Worker) => {
+    e.stopPropagation();
+    dragRef.current = { kind: 'move', id: w.id, sx: e.clientX, sy: e.clientY, ox: w.x, oy: w.y, ow: w.w, oh: w.h, moved: false };
+  };
+  const startResize = (e: React.PointerEvent, w: Worker) => {
+    e.stopPropagation();
+    dragRef.current = { kind: 'resize', id: w.id, sx: e.clientX, sy: e.clientY, ox: w.x, oy: w.y, ow: w.w, oh: w.h, moved: false };
+  };
+  useEffect(() => {
+    const move = (e: PointerEvent) => {
+      const d = dragRef.current; if (!d) return;
+      const dx = e.clientX - d.sx, dy = e.clientY - d.sy;
+      if (Math.abs(dx) > 3 || Math.abs(dy) > 3) d.moved = true;
+      if (d.kind === 'pan') setPan({ x: d.ox + dx, y: d.oy + dy });
+      else if (d.kind === 'move') setWorkers((prev) => prev.map((w) => w.id === d.id ? { ...w, x: d.ox + dx / zoom, y: d.oy + dy / zoom } : w));
+      else setWorkers((prev) => prev.map((w) => w.id === d.id ? { ...w, w: Math.max(MIN_W, d.ow + dx / zoom), h: Math.max(MIN_H, d.oh + dy / zoom) } : w));
+    };
+    const up = () => {
+      const d = dragRef.current;
+      if (d && !d.moved) { if (d.kind === 'move' && d.id) selectWorker(byId[d.id]); else if (d.kind === 'pan') setSelectedId(null); }
+      dragRef.current = null;
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+    return () => { window.removeEventListener('pointermove', move); window.removeEventListener('pointerup', up); };
+  }, [zoom, byId]);
+
+  const onWheel = (e: React.WheelEvent) => {
+    const next = clamp(zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1), Z_MIN, Z_MAX);
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
+    setPan((p) => ({ x: cx - (cx - p.x) * (next / zoom), y: cy - (cy - p.y) * (next / zoom) }));
+    setZoom(next);
   };
 
   const simulateDone = (who: string, t = '✅ work done') => {
@@ -145,34 +169,17 @@ export default function Office() {
   };
 
   const send = () => {
-    const body = text.trim();
-    if (!body) return;
-    if (mode === 'broadcast') {
-      push({ kind: 'broadcast', text: body });
-      setText('');
-      return;
-    }
+    const body = text.trim(); if (!body) return;
+    if (mode === 'broadcast') { push({ kind: 'broadcast', text: body }); setText(''); return; }
     if (!target) return;
     push({ kind: 'dispatch', to: target.id, text: body });
     setWorkers((prev) => prev.map((w) => (w.id === target.id ? { ...w, status: 'working', shown: 0 } : w)));
-    setText('');
-    simulateDone(target.id);
+    setText(''); simulateDone(target.id);
   };
 
-  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
-  };
-  const onChange = (v: string) => {
-    setText(v);
-    if (mode === 'single') setMentionOpen(/(^|\s)@$/.test(v));
-  };
-  const pickMention = (w: Worker) => {
-    setSelectedId(w.id); setMode('single');
-    setText((v) => v.replace(/@$/, ''));
-    setMentionOpen(false);
-    inputRef.current?.focus();
-  };
-
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } };
+  const onChange = (v: string) => { setText(v); if (mode === 'single') setMentionOpen(/(^|\s)@$/.test(v)); };
+  const pickMention = (w: Worker) => { setSelectedId(w.id); setMode('single'); setText((v) => v.replace(/@$/, '')); setMentionOpen(false); inputRef.current?.focus(); };
   const canSend = text.trim() && (mode === 'broadcast' || !!target);
 
   return (
@@ -184,79 +191,61 @@ export default function Office() {
           <span className="text-sm font-semibold text-zinc-100">办公室</span>
           <span className="text-[11px] text-zinc-500">· 总控 {SELF}</span>
         </div>
-
-        {/* history */}
         <div ref={chatRef} data-id="office-command-history" className="flex-1 space-y-2.5 overflow-auto px-3 py-3">
           {chat.map((m) => <CommandMsg key={m.id} m={m} byId={byId} />)}
         </div>
-
-        {/* prompt */}
         <div data-id="office-command-prompt" className="shrink-0 border-t border-[var(--vsc-border)] bg-[#0d0d0d] px-3 py-3">
           <div className="relative">
             <div data-id="office-mode" className="mb-2 inline-flex items-center gap-1 rounded-lg bg-white/[0.04] p-0.5 text-[12px]">
-              <button data-id="office-mode-single" onClick={() => setMode('single')}
-                className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'single' ? 'bg-white/10 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}`}>
-                <MessageSquare className="h-3.5 w-3.5" /> 单聊
-              </button>
-              <button data-id="office-mode-broadcast" onClick={() => { setMode('broadcast'); setMentionOpen(false); }}
-                className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'broadcast' ? 'bg-amber-500/20 text-amber-200' : 'text-zinc-500 hover:text-zinc-300'}`}>
-                <Megaphone className="h-3.5 w-3.5" /> 广播
-              </button>
+              <button data-id="office-mode-single" onClick={() => setMode('single')} className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'single' ? 'bg-white/10 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}`}><MessageSquare className="h-3.5 w-3.5" /> 单聊</button>
+              <button data-id="office-mode-broadcast" onClick={() => { setMode('broadcast'); setMentionOpen(false); }} className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'broadcast' ? 'bg-amber-500/20 text-amber-200' : 'text-zinc-500 hover:text-zinc-300'}`}><Megaphone className="h-3.5 w-3.5" /> 广播</button>
             </div>
-
             {mentionOpen && mode === 'single' && (
               <div data-id="office-mention" className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-xl border border-white/10 bg-[#141414] shadow-2xl">
                 {workers.map((w) => (
-                  <button key={w.id} data-id={`office-mention-${w.id}`} onClick={() => pickMention(w)}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-white/[0.06]">
-                    <Avatar emoji={w.emoji} accent={w.accent} size={22} />
-                    <span className="text-[13px] text-zinc-200">{w.name}</span>
-                    <span className="ml-auto font-mono text-[11px] text-zinc-500">{w.id}</span>
+                  <button key={w.id} data-id={`office-mention-${w.id}`} onClick={() => pickMention(w)} className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-white/[0.06]">
+                    <Avatar emoji={w.emoji} accent={w.accent} size={22} /><span className="text-[13px] text-zinc-200">{w.name}</span><span className="ml-auto font-mono text-[11px] text-zinc-500">{w.id}</span>
                   </button>
                 ))}
               </div>
             )}
-
             <div data-id="office-target" className="mb-2 flex items-center gap-1.5">
               {mode === 'broadcast' ? (
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-2.5 py-1 text-[12px] text-amber-200">
-                  <Megaphone className="h-3 w-3" /> 广播 · 全体（{workers.length}）
-                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-2.5 py-1 text-[12px] text-amber-200"><Megaphone className="h-3 w-3" /> 广播 · 全体（{workers.length}）</span>
               ) : target ? (
-                <span className="inline-flex items-center gap-1.5 rounded-full bg-sky-500/15 py-1 pl-1.5 pr-1.5 text-[12px] text-sky-300">
-                  <Avatar emoji={target.emoji} accent={target.accent} size={18} />
-                  <span className="font-mono">{target.id}</span>
-                  <button data-id="office-target-clear" onClick={() => setSelectedId(null)} className="rounded-full p-0.5 hover:bg-white/10"><X className="h-3 w-3" /></button>
-                </span>
-              ) : (
-                <span className="text-[12px] text-zinc-600">点右侧 worker，或 @ 选择</span>
-              )}
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-sky-500/15 py-1 pl-1.5 pr-1.5 text-[12px] text-sky-300"><Avatar emoji={target.emoji} accent={target.accent} size={18} /><span className="font-mono">{target.id}</span><button data-id="office-target-clear" onClick={() => setSelectedId(null)} className="rounded-full p-0.5 hover:bg-white/10"><X className="h-3 w-3" /></button></span>
+              ) : (<span className="text-[12px] text-zinc-600">点画布里的 worker，或 @ 选择</span>)}
             </div>
-
             <div className="flex items-end gap-2 rounded-xl border border-white/10 bg-[#111] px-3 py-2 focus-within:border-white/20">
-              <textarea ref={inputRef} data-id="office-input" rows={1} value={text}
-                onChange={(e) => onChange(e.target.value)} onKeyDown={onKeyDown}
+              <textarea ref={inputRef} data-id="office-input" rows={1} value={text} onChange={(e) => onChange(e.target.value)} onKeyDown={onKeyDown}
                 placeholder={mode === 'broadcast' ? '向全体广播…（Enter）' : target ? `给 ${target.name} 派任务…（Enter）` : '@ 选择 worker…'}
                 className="max-h-40 min-h-[24px] flex-1 resize-none bg-transparent text-[13px] leading-6 text-zinc-200 outline-none placeholder:text-zinc-600" />
-              <button data-id="office-send" onClick={send} disabled={!canSend}
-                className={`grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white transition-colors disabled:cursor-not-allowed disabled:bg-white/[0.06] disabled:text-zinc-600 ${mode === 'broadcast' ? 'bg-amber-500/90 hover:bg-amber-400' : 'bg-sky-500/90 hover:bg-sky-400'}`}>
-                {mode === 'broadcast' ? <Megaphone className="h-4 w-4" /> : <Send className="h-4 w-4" />}
-              </button>
+              <button data-id="office-send" onClick={send} disabled={!canSend} className={`grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white transition-colors disabled:cursor-not-allowed disabled:bg-white/[0.06] disabled:text-zinc-600 ${mode === 'broadcast' ? 'bg-amber-500/90 hover:bg-amber-400' : 'bg-sky-500/90 hover:bg-sky-400'}`}>{mode === 'broadcast' ? <Megaphone className="h-4 w-4" /> : <Send className="h-4 w-4" />}</button>
             </div>
           </div>
         </div>
       </aside>
 
-      {/* 右侧：worker chat window 网格 */}
-      <main data-id="office-windows" className="min-w-0 flex-1 overflow-auto bg-[#080808] p-4">
-        <div className="mb-3 flex items-center gap-2 text-[11px] text-zinc-500">
+      {/* 右侧：可拖拽/缩放的画布 */}
+      <main data-id="office-canvas" className="relative min-w-0 flex-1 overflow-hidden bg-[#080808]"
+        style={{ backgroundImage: 'radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px)', backgroundSize: `${24 * zoom}px ${24 * zoom}px`, backgroundPosition: `${pan.x}px ${pan.y}px` }}
+        onPointerDown={onPointerDownBg} onWheel={onWheel}>
+        <div data-id="office-canvas-layer" className="absolute left-0 top-0 origin-top-left" style={{ transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})` }}>
+          {workers.map((w) => (
+            <WorkerWindow key={w.id} w={w} selected={selectedId === w.id}
+              onMoveStart={(e) => startMove(e, w)} onResizeStart={(e) => startResize(e, w)} />
+          ))}
+        </div>
+
+        <div data-id="office-canvas-stats" className="pointer-events-none absolute left-3 top-3 flex items-center gap-2 text-[11px] text-zinc-500">
           <span className="rounded-md bg-white/[0.04] px-2 py-1">{workers.length} 个 worker</span>
           <span className="rounded-md bg-white/[0.03] px-2 py-1 text-zinc-600">只显示 thinking + text · tool 结果不拉</span>
         </div>
-        <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(360px, 1fr))' }}>
-          {workers.map((w) => (
-            <WorkerWindow key={w.id} w={w} selected={selectedId === w.id} onSelect={() => selectWorker(w)} />
-          ))}
+        <div data-id="office-canvas-controls" className="absolute bottom-4 right-4 flex flex-col gap-1.5">
+          <button data-id="office-zoom-in" onClick={() => setZoom((z) => clamp(z * 1.15, Z_MIN, Z_MAX))} className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Plus className="h-4 w-4" /></button>
+          <button data-id="office-zoom-out" onClick={() => setZoom((z) => clamp(z / 1.15, Z_MIN, Z_MAX))} className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Minus className="h-4 w-4" /></button>
+          <button data-id="office-zoom-reset" onClick={() => { setPan({ x: 0, y: 0 }); setZoom(1); }} title="复位" className="grid h-8 w-8 place-items-center rounded-lg border border-white/10 bg-[#141414] text-zinc-400 hover:text-zinc-100"><Maximize2 className="h-4 w-4" /></button>
+          <div className="text-center text-[10px] text-zinc-600">{Math.round(zoom * 100)}%</div>
         </div>
       </main>
     </div>
@@ -264,81 +253,61 @@ export default function Office() {
 }
 
 function CommandMsg({ m, byId }: { m: ChatMsg; byId: Record<string, Worker> }) {
-  if (m.kind === 'note') {
-    return <div data-id={`office-msg-${m.id}`} className="text-center text-[11.5px] leading-relaxed text-zinc-600">{m.text}</div>;
-  }
-  if (m.kind === 'broadcast') {
-    return (
-      <div data-id={`office-msg-${m.id}`} className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-2.5 py-1.5 text-[12.5px] text-amber-50/90">
-        <span className="mr-1 text-[11px] text-amber-300/80">📢 广播 · 全体</span>
-        <div className="whitespace-pre-wrap">{m.text}</div>
-      </div>
-    );
-  }
+  if (m.kind === 'note') return <div data-id={`office-msg-${m.id}`} className="text-center text-[11.5px] leading-relaxed text-zinc-600">{m.text}</div>;
+  if (m.kind === 'broadcast') return (
+    <div data-id={`office-msg-${m.id}`} className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-2.5 py-1.5 text-[12.5px] text-amber-50/90"><span className="mr-1 text-[11px] text-amber-300/80">📢 广播 · 全体</span><div className="whitespace-pre-wrap">{m.text}</div></div>
+  );
   if (m.kind === 'dispatch') {
     const w = m.to ? byId[m.to] : null;
     return (
       <div data-id={`office-msg-${m.id}`} className="flex flex-col items-end gap-0.5">
-        <div className="flex items-center gap-1 text-[11px] text-zinc-500">
-          <AtSign className="h-3 w-3" /><span className="font-mono">{m.to}</span>{w && <span>{w.name}</span>}
-        </div>
+        <div className="flex items-center gap-1 text-[11px] text-zinc-500"><AtSign className="h-3 w-3" /><span className="font-mono">{m.to}</span>{w && <span>{w.name}</span>}</div>
         <div className="max-w-[88%] rounded-lg rounded-tr-sm bg-sky-500/15 px-2.5 py-1.5 text-[12.5px] text-sky-100 whitespace-pre-wrap">{m.text}</div>
       </div>
     );
   }
-  // done
   const w = m.from ? byId[m.from] : null;
   return (
     <div data-id={`office-msg-${m.id}`} className="flex items-center gap-1.5">
       {w && <Avatar emoji={w.emoji} accent={w.accent} size={20} />}
-      <span className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/10 px-2 py-1 text-[12px] text-emerald-300">
-        <CheckCircle2 className="h-3.5 w-3.5" /> {m.text}
-      </span>
+      <span className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/10 px-2 py-1 text-[12px] text-emerald-300"><CheckCircle2 className="h-3.5 w-3.5" /> {m.text}</span>
       <span className="ml-auto text-[10px] text-zinc-700">{m.ts}</span>
     </div>
   );
 }
 
-function WorkerWindow({ w, selected, onSelect }: { w: Worker; selected: boolean; onSelect: () => void }) {
+function WorkerWindow({ w, selected, onMoveStart, onResizeStart }: {
+  w: Worker; selected: boolean; onMoveStart: (e: React.PointerEvent) => void; onResizeStart: (e: React.PointerEvent) => void;
+}) {
   const acc = ACCENT[w.accent] ?? ACCENT.sky;
-  const st = STATUS_META[w.status];
-  const lines = w.script.slice(0, w.shown).slice(-10);
+  const lines = w.script.slice(0, w.shown).slice(-12);
   const bodyRef = useRef<HTMLDivElement>(null);
   useEffect(() => { const n = bodyRef.current; if (n) n.scrollTop = n.scrollHeight; }, [w.shown]);
 
   return (
-    <button
-      data-id={`office-window-${w.id}`}
-      onClick={onSelect}
-      className={`flex h-[260px] flex-col overflow-hidden rounded-xl border bg-[#0e0e0e] text-left transition-colors ${selected ? `ring-2 ${acc.ring} border-transparent` : 'border-white/[0.07] hover:border-white/15'}`}
-    >
-      <div data-id={`office-window-header-${w.id}`} className="flex shrink-0 items-center gap-2 border-b border-white/[0.06] bg-white/[0.02] px-3 py-2">
+    <div data-id={`office-window-${w.id}`}
+      className={`absolute flex flex-col overflow-hidden rounded-xl border bg-[#0e0e0e] shadow-xl ${selected ? `ring-2 ${acc.ring} border-transparent` : 'border-white/[0.08]'}`}
+      style={{ left: w.x, top: w.y, width: w.w, height: w.h, zIndex: selected ? 50 : 10 }}>
+      <div data-id={`office-window-header-${w.id}`} onPointerDown={onMoveStart} className="flex shrink-0 cursor-grab items-center gap-2 border-b border-white/[0.06] bg-white/[0.02] px-3 py-2 active:cursor-grabbing">
         <Avatar emoji={w.emoji} accent={w.accent} size={30} />
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-[13px] font-medium text-zinc-200">{w.name}</span>
-          <span className="font-mono text-[10.5px] text-zinc-500">{w.id} · {w.role}</span>
-        </span>
+        <span className="min-w-0 flex-1"><span className="block truncate text-[13px] font-medium text-zinc-200">{w.name}</span><span className="font-mono text-[10.5px] text-zinc-500">{w.id} · {w.role}</span></span>
         <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] ${acc.chip}`}>
-          {w.status === 'working' ? <Loader2 className="h-3 w-3 animate-spin" /> :
-           w.status === 'done' ? <CheckCircle2 className="h-3 w-3" /> :
-           <CircleDot className={`h-3 w-3 ${acc.dot}`} />}
-          {st.label}
+          {w.status === 'working' ? <Loader2 className="h-3 w-3 animate-spin" /> : w.status === 'done' ? <CheckCircle2 className="h-3 w-3" /> : <CircleDot className={`h-3 w-3 ${acc.dot}`} />}
+          {STATUS_META[w.status].label}
         </span>
       </div>
-
       <div ref={bodyRef} data-id={`office-window-body-${w.id}`} className="flex-1 space-y-1.5 overflow-auto px-3 py-2">
-        {lines.length === 0 ? (
-          <div className="text-[11.5px] text-zinc-600">待派活…</div>
-        ) : lines.map((ln, i) => (
+        {lines.length === 0 ? <div className="text-[11.5px] text-zinc-600">待派活…</div> : lines.map((ln, i) => (
           ln.t === 'thinking'
             ? <div key={i} className="border-l-2 border-amber-300/25 pl-2 text-[11.5px] leading-relaxed text-amber-50/55">{ln.s}</div>
             : <div key={i} className="text-[12px] leading-relaxed text-zinc-300">{ln.s}</div>
         ))}
       </div>
-
-      {w.status === 'done' && (
-        <div className="shrink-0 border-t border-emerald-500/15 bg-emerald-500/[0.06] px-3 py-1 text-[10.5px] text-emerald-300/90">✅ work done · 等总控验收</div>
-      )}
-    </button>
+      {w.status === 'done' && <div className="shrink-0 border-t border-emerald-500/15 bg-emerald-500/[0.06] px-3 py-1 text-[10.5px] text-emerald-300/90">✅ work done · 等总控验收</div>}
+      {/* resize 角 */}
+      <div data-id={`office-window-resize-${w.id}`} onPointerDown={onResizeStart}
+        className="absolute bottom-0 right-0 h-4 w-4 cursor-nwse-resize"
+        style={{ background: 'linear-gradient(135deg, transparent 50%, rgba(255,255,255,0.25) 50%)' }} />
+    </div>
   );
 }

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, MessageSquare,
-  Plus, Minus, Maximize2, Crown, Inbox,
+  Plus, Minus, Maximize2, Crown, Inbox, UserPlus, Sparkles, ChevronRight, Power, Users,
 } from 'lucide-react';
 
 /*
@@ -18,6 +18,7 @@ type Status = 'idle' | 'working' | 'done';
 
 interface Worker {
   id: string; name: string; role: string; emoji: string; accent: string;
+  model: string; ctx: number; ctxK: number;   // 模型 + 上下文用量(%) + 上下文窗口(k)
   status: Status; script: Line[]; shown: number; startedAt: number;
   x: number; y: number; w: number; h: number;
 }
@@ -28,34 +29,34 @@ interface ChatMsg { id: number; kind: ChatKind; from?: string; to?: string; text
 const SELF = 'w-10001';
 const MIN_W = 240, MIN_H = 168;
 
-const W = (id: string, name: string, role: string, emoji: string, accent: string, status: Status, x: number, y: number, script: Line[]): Worker =>
-  ({ id, name, role, emoji, accent, status, script, shown: status === 'working' ? 0 : script.length, startedAt: 0, x, y, w: 312, h: 232 });
+const W = (id: string, name: string, role: string, emoji: string, accent: string, model: string, ctx: number, ctxK: number, status: Status, x: number, y: number, script: Line[]): Worker =>
+  ({ id, name, role, emoji, accent, model, ctx, ctxK, status, script, shown: status === 'working' ? 0 : script.length, startedAt: 0, x, y, w: 312, h: 248 });
 
 const INIT_WORKERS: Worker[] = [
-  W('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 'working', 36, 32, [
+  W('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 'deepseek-v4-pro', 42, 256, 'working', 36, 32, [
     { t: 'thinking', s: '把"画布"拆成 3 张卡：数据层 / 渲染层 / 画布层。' },
     { t: 'text', s: '定义 LiteAgentCard props + digest 端点契约。' },
     { t: 'thinking', s: 'tool_result 不传，payload 小一个数量级。' },
     { t: 'text', s: '接口写进 docs，交给 Finn。' },
     { t: 'text', s: '✅ 完成：技术任务卡 + 接口契约。' },
   ]),
-  W('w-10011', '前端 Finn', 'dev-junior', '🎨', 'violet', 'working', 384, 32, [
+  W('w-10011', '前端 Finn', 'dev-junior', '🎨', 'violet', 'deepseek-v4-pro', 61, 256, 'working', 384, 32, [
     { t: 'thinking', s: '复用 normalize，搭可拖拽/缩放的 window。' },
     { t: 'text', s: '左栏指挥台 + 右栏画布。' },
     { t: 'thinking', s: '选中 window → prompt 自动 @ 它。' },
     { t: 'text', s: '加 drag handle + resize 抓手。' },
     { t: 'text', s: '✅ 完成：可拖拽缩放的办公室画布。' },
   ]),
-  W('w-10012', '测试 Quinn', 'qa', '🧪', 'emerald', 'working', 732, 32, [
+  W('w-10012', '测试 Quinn', 'qa', '🧪', 'emerald', 'gpt-5.5', 38, 400, 'working', 732, 32, [
     { t: 'thinking', s: '核对验收标准：N window 同屏不卡。' },
     { t: 'text', s: '跑 20 window 压力，盯帧率。' },
     { t: 'thinking', s: 'thinking 太长要截断。' },
     { t: 'text', s: 'FAIL：离屏 window 仍在轮询，需门控。' },
   ]),
-  W('w-10013', '运维 Ops', 'ops', '🚀', 'amber', 'idle', 210, 296, [
+  W('w-10013', '运维 Ops', 'ops', '🚀', 'amber', 'deepseek-v4-pro', 8, 256, 'idle', 210, 296, [
     { t: 'text', s: '待构建产物，准备部署。' },
   ]),
-  W('w-10014', '安全 Sage', 'reviewer', '🛡️', 'rose', 'working', 558, 296, [
+  W('w-10014', '安全 Sage', 'reviewer', '🛡️', 'rose', 'claude-haiku-4-5', 84, 200, 'working', 558, 296, [
     { t: 'thinking', s: '扫一遍有没有把 token 渲进 window。' },
     { t: 'text', s: 'text+thinking 不含工具入参，攻击面更小。' },
     { t: 'text', s: '✅ 完成：安全结论 PASS。' },
@@ -91,6 +92,37 @@ function Avatar({ emoji, accent, size = 30, status }: { emoji: string; accent: s
   );
 }
 
+/* ── 候选成员（存在但未加入/未开启 = 离线）── */
+interface Cand { id: string; name: string; role: string; emoji: string; accent: string; model: string; script: Line[] }
+/* ── 模版成员（我们提供的角色预设，点击按模版创建新成员）── */
+interface Tmpl { key: string; name: string; role: string; emoji: string; accent: string; model: string; script: Line[] }
+
+const GENERIC_SCRIPT: Line[] = [
+  { t: 'thinking', s: '读取任务卡与验收标准…' },
+  { t: 'text', s: '开始执行。' },
+  { t: 'thinking', s: '检查边界条件与依赖。' },
+  { t: 'text', s: '✅ 完成，等待验收。' },
+];
+
+const INIT_CANDIDATES: Cand[] = [
+  { id: 'w-10015', name: '文案 Wendy', role: 'writer', emoji: '✍️', accent: 'violet', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
+  { id: 'w-10016', name: '数据 Dана', role: 'analyst', emoji: '📊', accent: 'sky', model: 'gpt-5.5', script: GENERIC_SCRIPT },
+  { id: 'w-10017', name: '设计 Deo', role: 'designer', emoji: '🎭', accent: 'rose', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
+];
+
+const TEMPLATES: Tmpl[] = [
+  { key: 'arch', name: '架构师', role: 'dev-senior', emoji: '🏛️', accent: 'sky', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
+  { key: 'be', name: '后端开发', role: 'dev', emoji: '🛠️', accent: 'violet', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
+  { key: 'fe', name: '前端开发', role: 'dev-junior', emoji: '🎨', accent: 'violet', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
+  { key: 'qa', name: '测试', role: 'qa', emoji: '🧪', accent: 'emerald', model: 'gpt-5.5', script: GENERIC_SCRIPT },
+  { key: 'ops', name: '运维', role: 'ops', emoji: '🚀', accent: 'amber', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
+  { key: 'sec', name: '安全', role: 'reviewer', emoji: '🛡️', accent: 'rose', model: 'claude-haiku-4-5', script: GENERIC_SCRIPT },
+];
+
+function makeWorker(id: string, name: string, role: string, emoji: string, accent: string, model: string, slot: number, script: Line[]): Worker {
+  return { id, name, role, emoji, accent, model, ctx: 5, ctxK: 256, status: 'idle', script, shown: 0, startedAt: 0, w: 312, h: 248, x: 36 + (slot % 3) * 372, y: 32 + Math.floor(slot / 3) * 280 };
+}
+
 export default function Office() {
   const [workers, setWorkers] = useState<Worker[]>(() => {
     const t0 = Date.now();
@@ -107,6 +139,9 @@ export default function Office() {
   const [chat, setChat] = useState<ChatMsg[]>([
     { id: 1, kind: 'note', text: '拖标题移动卡片、拖右下角缩放、空白拖拽平移、滚轮缩放。点 worker 自动 @ 派任务，或切广播。', ts: hhmm(Date.now()) },
   ]);
+  const [candidates, setCandidates] = useState<Cand[]>(INIT_CANDIDATES);
+  const [rosterOpen, setRosterOpen] = useState(true);
+  const idSeq = useRef(20);
   const seq = useRef(2);
   const chatRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -121,7 +156,10 @@ export default function Office() {
     const t = window.setInterval(() => {
       const ts = Date.now();
       setWorkers((prev) => prev.map((w) => {
-        if (w.status === 'working') return w.shown < w.script.length ? { ...w, shown: w.shown + 1 } : { ...w, status: 'done' };
+        if (w.status === 'working') {
+          const ctx = Math.min(99, w.ctx + 1 + Math.floor(Math.random() * 3));   // 上下文随干活增长
+          return w.shown < w.script.length ? { ...w, shown: w.shown + 1, ctx } : { ...w, status: 'done', ctx };
+        }
         if (w.status === 'done' && Math.random() < 0.08) return { ...w, status: 'working', shown: 0, startedAt: ts };
         return w;
       }));
@@ -182,6 +220,16 @@ export default function Office() {
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } };
   const onChange = (v: string) => { setText(v); if (mode === 'single') setMentionOpen(/(^|\s)@$/.test(v)); };
   const pickMention = (w: Worker) => { setSelectedId(w.id); setMode('single'); setText((v) => v.replace(/@$/, '')); setMentionOpen(false); inputRef.current?.focus(); };
+  const joinCandidate = (c: Cand) => {
+    setCandidates((prev) => prev.filter((x) => x.id !== c.id));
+    setWorkers((prev) => [...prev, makeWorker(c.id, c.name, c.role, c.emoji, c.accent, c.model, prev.length, c.script)]);
+    push({ kind: 'note', text: `已加入并启用 ${c.name}（${c.id}）` });
+  };
+  const createFromTemplate = (t: Tmpl) => {
+    const id = `w-100${idSeq.current++}`;
+    setWorkers((prev) => [...prev, makeWorker(id, t.name, t.role, t.emoji, t.accent, t.model, prev.length, t.script)]);
+    push({ kind: 'note', text: `已按模版「${t.name}」创建 ${id}` });
+  };
   const canSend = text.trim() && (mode === 'broadcast' || !!target);
 
   return (
@@ -262,6 +310,49 @@ export default function Office() {
           <div className="text-center text-[10px] text-zinc-600">{Math.round(zoom * 100)}%</div>
         </div>
       </main>
+
+      {/* 右栏：成员库（候选 + 模版） */}
+      {rosterOpen ? (
+        <aside data-id="office-roster" className="flex w-[268px] min-w-[268px] shrink-0 flex-col border-l border-white/[0.06] bg-[#0b0b0c]">
+          <div className="flex h-14 shrink-0 items-center gap-2 border-b border-white/[0.06] px-4">
+            <Users className="h-4 w-4 text-zinc-400" />
+            <span className="text-[13px] font-semibold text-zinc-100">成员库</span>
+            <button data-id="office-roster-close" onClick={() => setRosterOpen(false)} className="ml-auto rounded p-1 text-zinc-500 hover:bg-white/10 hover:text-zinc-200"><ChevronRight className="h-4 w-4" /></button>
+          </div>
+          <div className="flex-1 space-y-5 overflow-auto px-3 py-3.5">
+            <section data-id="office-roster-candidates">
+              <div className="mb-2 flex items-center gap-1.5 px-1 text-[11px] font-medium uppercase tracking-wide text-zinc-600"><Power className="h-3 w-3" /> 候选 · 未开启<span className="ml-auto normal-case text-zinc-700">{candidates.length}</span></div>
+              {candidates.length === 0 ? <div className="px-1 text-[11.5px] text-zinc-700">全部已加入</div> : (
+                <div className="space-y-1.5">
+                  {candidates.map((c) => (
+                    <div key={c.id} data-id={`office-cand-${c.id}`} className="flex items-center gap-2.5 rounded-xl border border-white/[0.06] bg-white/[0.02] px-2.5 py-2">
+                      <span className="opacity-50 grayscale"><Avatar emoji={c.emoji} accent={c.accent} size={28} /></span>
+                      <span className="min-w-0 flex-1"><span className="block truncate text-[12.5px] text-zinc-300">{c.name}</span><span className="font-mono text-[10.5px] text-zinc-600">{c.id} · 离线</span></span>
+                      <button data-id={`office-cand-join-${c.id}`} onClick={() => joinCandidate(c)} className="inline-flex items-center gap-1 rounded-lg bg-white/[0.06] px-2 py-1 text-[11.5px] text-zinc-200 transition-colors hover:bg-white/[0.12]"><UserPlus className="h-3.5 w-3.5" /> 加入</button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </section>
+            <section data-id="office-roster-templates">
+              <div className="mb-2 flex items-center gap-1.5 px-1 text-[11px] font-medium uppercase tracking-wide text-zinc-600"><Sparkles className="h-3 w-3" /> 模版 · 点击创建<span className="ml-auto normal-case text-zinc-700">{TEMPLATES.length}</span></div>
+              <div className="space-y-1.5">
+                {TEMPLATES.map((t) => (
+                  <div key={t.key} data-id={`office-tmpl-${t.key}`} className="flex items-center gap-2.5 rounded-xl border border-dashed border-white/[0.09] bg-white/[0.015] px-2.5 py-2">
+                    <Avatar emoji={t.emoji} accent={t.accent} size={28} />
+                    <span className="min-w-0 flex-1"><span className="block truncate text-[12.5px] text-zinc-300">{t.name}</span><span className="block truncate text-[10.5px] text-zinc-600">{t.role}</span></span>
+                    <button data-id={`office-tmpl-create-${t.key}`} onClick={() => createFromTemplate(t)} className="inline-flex items-center gap-1 rounded-lg bg-sky-500/15 px-2 py-1 text-[11.5px] text-sky-300 transition-colors hover:bg-sky-500/25"><Plus className="h-3.5 w-3.5" /> 创建</button>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </div>
+        </aside>
+      ) : (
+        <button data-id="office-roster-open" onClick={() => setRosterOpen(true)}
+          className="absolute right-0 top-1/2 z-30 flex -translate-y-1/2 items-center gap-1.5 rounded-l-lg border border-r-0 border-white/10 bg-[#16161a]/90 px-2 py-3 text-[11px] text-zinc-400 backdrop-blur transition-colors hover:text-zinc-100"
+          style={{ writingMode: 'vertical-rl' }}><Users className="h-3.5 w-3.5" /> 成员库</button>
+      )}
     </div>
   );
 }
@@ -306,6 +397,8 @@ function WorkerWindow({ w, now, selected, hovered, onHover, onMoveStart, onResiz
   useEffect(() => { const n = bodyRef.current; if (n) n.scrollTop = n.scrollHeight; }, [w.shown]);
   const done = w.status === 'done';
   const working = w.status === 'working';
+  const ctxColor = w.ctx > 85 ? 'bg-rose-400' : w.ctx > 60 ? 'bg-amber-400' : 'bg-zinc-400/60';
+  const ctxText = w.ctx > 85 ? 'text-rose-300' : w.ctx > 60 ? 'text-amber-300' : 'text-zinc-500';
 
   return (
     <div data-id={`office-window-${w.id}`}
@@ -330,7 +423,15 @@ function WorkerWindow({ w, now, selected, hovered, onHover, onMoveStart, onResiz
           <span className="text-[10.5px] text-zinc-600">空闲</span>
         )}
       </div>
-      <div className="mx-3 h-px bg-white/[0.05]" />
+      {/* meta：模型 + 上下文用量 */}
+      <div data-id={`office-window-meta-${w.id}`} className="flex items-center gap-2 border-b border-white/[0.05] px-3 py-1.5">
+        <span className="truncate rounded bg-white/[0.05] px-1.5 py-0.5 font-mono text-[10px] text-zinc-400" title={`模型 ${w.model}`}>{w.model}</span>
+        <div className="ml-auto flex items-center gap-1.5" title={`上下文 ${w.ctx}% · 窗口 ${w.ctxK}k`}>
+          <span className="text-[10px] text-zinc-600">ctx</span>
+          <div className="h-1 w-14 overflow-hidden rounded-full bg-white/10"><div className={`h-full rounded-full ${ctxColor} transition-all`} style={{ width: `${w.ctx}%` }} /></div>
+          <span className={`text-[10px] tabular-nums ${ctxText}`}>{w.ctx}%</span>
+        </div>
+      </div>
       <div ref={bodyRef} data-id={`office-window-body-${w.id}`} className="flex-1 space-y-2 overflow-auto px-3 py-2.5">
         {lines.length === 0 ? (
           <div className="flex h-full flex-col items-center justify-center gap-1 text-zinc-700"><Inbox className="h-5 w-5" /><span className="text-[11px]">等待派活</span></div>

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, MessageSquare,
-  Plus, Minus, Maximize2, Crown, Inbox, UserPlus, ChevronRight, Power, Users, Store,
+  Plus, Minus, Maximize2, Crown, Inbox, UserPlus, ChevronRight, Power, Users, Store, Copy, Check,
 } from 'lucide-react';
 import TemplateMarket, { MarketTmpl, TeamTmpl } from './TemplateMarket';
 
@@ -31,7 +31,7 @@ const SELF = 'w-10001';
 const MIN_W = 240, MIN_H = 168;
 
 const W = (id: string, name: string, role: string, emoji: string, accent: string, model: string, ctx: number, ctxK: number, status: Status, x: number, y: number, script: Line[]): Worker =>
-  ({ id, name, role, emoji, accent, model, ctx, ctxK, status, script, shown: status === 'working' ? 0 : script.length, startedAt: 0, x, y, w: 312, h: 248 });
+  ({ id, name, role, emoji, accent, model, ctx, ctxK, status, script, shown: status === 'working' ? 0 : script.length, startedAt: 0, x, y, w: 360, h: 248 });
 
 const INIT_WORKERS: Worker[] = [
   W('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 'deepseek-v4-pro', 42, 256, 'working', 36, 32, [
@@ -110,7 +110,7 @@ const INIT_CANDIDATES: Cand[] = [
 ];
 
 function makeWorker(id: string, name: string, role: string, emoji: string, accent: string, model: string, slot: number, script: Line[]): Worker {
-  return { id, name, role, emoji, accent, model, ctx: 5, ctxK: 256, status: 'idle', script, shown: 0, startedAt: 0, w: 312, h: 248, x: 36 + (slot % 3) * 372, y: 32 + Math.floor(slot / 3) * 280 };
+  return { id, name, role, emoji, accent, model, ctx: 5, ctxK: 256, status: 'idle', script, shown: 0, startedAt: 0, w: 360, h: 248, x: 36 + (slot % 3) * 372, y: 32 + Math.floor(slot / 3) * 280 };
 }
 
 export default function Office() {
@@ -400,6 +400,8 @@ function WorkerWindow({ w, now, selected, hovered, onHover, onMoveStart, onResiz
   const working = w.status === 'working';
   const ctxColor = w.ctx > 85 ? 'bg-rose-400' : w.ctx > 60 ? 'bg-amber-400' : 'bg-zinc-400/60';
   const ctxText = w.ctx > 85 ? 'text-rose-300' : w.ctx > 60 ? 'text-amber-300' : 'text-zinc-500';
+  const [copied, setCopied] = useState(false);
+  const copyId = (e: React.MouseEvent) => { e.stopPropagation(); try { navigator.clipboard?.writeText(w.id); } catch { /* noop */ } setCopied(true); window.setTimeout(() => setCopied(false), 1200); };
 
   return (
     <div data-id={`office-window-${w.id}`}
@@ -410,11 +412,17 @@ function WorkerWindow({ w, now, selected, hovered, onHover, onMoveStart, onResiz
       {/* 角色色条 */}
       <div className={`h-[3px] w-full ${done ? 'bg-emerald-400/60' : acc.bar}`} />
       <div data-id={`office-window-header-${w.id}`} onPointerDown={onMoveStart}
-        className={`flex shrink-0 cursor-grab items-center gap-2.5 px-3 py-2.5 active:cursor-grabbing ${done ? 'bg-emerald-500/[0.05]' : 'bg-white/[0.015]'}`}>
+        className={`flex shrink-0 cursor-grab select-none items-center gap-2.5 px-3 py-2.5 active:cursor-grabbing ${done ? 'bg-emerald-500/[0.05]' : 'bg-white/[0.015]'}`}>
         <Avatar emoji={w.emoji} accent={w.accent} size={32} status={w.status} />
         <span className="min-w-0 flex-1">
           <span className="block truncate text-[13px] font-semibold text-zinc-100">{w.name}</span>
-          <span className="font-mono text-[10.5px] text-zinc-500">{w.id} · {w.role}</span>
+          <span className="flex items-center gap-1 font-mono text-[10.5px] text-zinc-500">
+            <button data-id={`office-window-copyid-${w.id}`} onPointerDown={(e) => e.stopPropagation()} onClick={copyId}
+              title="复制 agent id" className="inline-flex items-center gap-0.5 rounded px-0.5 transition-colors hover:bg-white/10 hover:text-zinc-300">
+              {w.id}{copied ? <Check className="h-2.5 w-2.5 text-emerald-400" /> : <Copy className="h-2.5 w-2.5 opacity-50" />}
+            </button>
+            · {w.role}
+          </span>
         </span>
         {done ? (
           <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/15 px-2 py-0.5 text-[10.5px] font-medium text-emerald-300"><CheckCircle2 className="h-3 w-3" /> 待验收</span>

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -3,7 +3,7 @@ import {
   Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, MessageSquare,
   Plus, Minus, Maximize2, Crown, Inbox, UserPlus, ChevronRight, Power, Users, Store,
 } from 'lucide-react';
-import TemplateMarket, { MarketTmpl } from './TemplateMarket';
+import TemplateMarket, { MarketTmpl, TeamTmpl } from './TemplateMarket';
 
 /*
  * Office — 「办公室」（data-id="office"）。
@@ -222,6 +222,11 @@ export default function Office() {
     push({ kind: 'note', text: `${note} ${id}` });
   };
   const pickFromMarket = (t: MarketTmpl) => spawn(t.name, t.role, t.emoji, t.accent, t.model, `已从模版市场添加「${t.name}」`);
+  const pickTeam = (team: TeamTmpl) => {
+    const base = idSeq.current; idSeq.current += team.members.length;
+    setWorkers((prev) => [...prev, ...team.members.map((m, i) => makeWorker(`w-100${base + i}`, m.name, m.role, m.emoji, m.accent, m.model, prev.length + i, GENERIC_SCRIPT))]);
+    push({ kind: 'note', text: `已组建「${team.name}」（${team.members.length} 名成员）` });
+  };
   const canSend = text.trim() && (mode === 'broadcast' || !!target);
 
   return (
@@ -343,7 +348,7 @@ export default function Office() {
           style={{ writingMode: 'vertical-rl' }}><Users className="h-3.5 w-3.5" /> 成员库</button>
       )}
 
-      <TemplateMarket open={marketOpen} onClose={() => setMarketOpen(false)} onPick={pickFromMarket} />
+      <TemplateMarket open={marketOpen} onClose={() => setMarketOpen(false)} onPick={pickFromMarket} onPickTeam={pickTeam} />
     </div>
   );
 }

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -131,7 +131,7 @@ export default function Office() {
   ]);
   const [candidates, setCandidates] = useState<Cand[]>(INIT_CANDIDATES);
   const [rosterOpen, setRosterOpen] = useState(true);
-  const [marketOpen, setMarketOpen] = useState(false);
+  const [market, setMarket] = useState<'team' | 'agent' | null>(null);
   const idSeq = useRef(20);
   const seq = useRef(2);
   const chatRef = useRef<HTMLDivElement>(null);
@@ -331,15 +331,20 @@ export default function Office() {
                 </div>
               )}
             </section>
-            <button data-id="office-open-market" onClick={() => setMarketOpen(true)}
-              className="flex w-full items-center gap-3 rounded-xl border border-sky-400/20 bg-sky-500/10 px-3 py-3 text-left transition-colors hover:border-sky-400/40 hover:bg-sky-500/15">
-              <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-sky-500/20 text-sky-300"><Store className="h-5 w-5" /></span>
-              <span className="min-w-0 flex-1">
-                <span className="block text-[13px] font-medium text-zinc-100">Agent 模版市场</span>
-                <span className="block text-[11px] text-zinc-500">浏览各行各业的预置 agent</span>
-              </span>
-              <ChevronRight className="h-4 w-4 text-zinc-500" />
-            </button>
+            <div className="space-y-2">
+              <button data-id="office-open-team-market" onClick={() => setMarket('team')}
+                className="flex w-full items-center gap-3 rounded-xl border border-sky-400/20 bg-sky-500/10 px-3 py-3 text-left transition-colors hover:border-sky-400/40 hover:bg-sky-500/15">
+                <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-sky-500/20 text-sky-300"><Users className="h-5 w-5" /></span>
+                <span className="min-w-0 flex-1"><span className="block text-[13px] font-medium text-zinc-100">团队市场</span><span className="block text-[11px] text-zinc-500">一键组建整支班子</span></span>
+                <ChevronRight className="h-4 w-4 text-zinc-500" />
+              </button>
+              <button data-id="office-open-agent-market" onClick={() => setMarket('agent')}
+                className="flex w-full items-center gap-3 rounded-xl border border-white/[0.08] bg-white/[0.03] px-3 py-3 text-left transition-colors hover:border-white/15 hover:bg-white/[0.05]">
+                <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-white/[0.06] text-zinc-300"><Store className="h-5 w-5" /></span>
+                <span className="min-w-0 flex-1"><span className="block text-[13px] font-medium text-zinc-100">Agent 市场</span><span className="block text-[11px] text-zinc-500">各行各业单个 agent 模版</span></span>
+                <ChevronRight className="h-4 w-4 text-zinc-500" />
+              </button>
+            </div>
           </div>
         </aside>
       ) : (
@@ -348,7 +353,7 @@ export default function Office() {
           style={{ writingMode: 'vertical-rl' }}><Users className="h-3.5 w-3.5" /> 成员库</button>
       )}
 
-      <TemplateMarket open={marketOpen} onClose={() => setMarketOpen(false)} onPick={pickFromMarket} onPickTeam={pickTeam} />
+      <TemplateMarket open={market} onClose={() => setMarket(null)} onPick={pickFromMarket} onPickTeam={pickTeam} />
     </div>
   );
 }

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, MessageSquare,
-  Plus, Minus, Maximize2, Crown, Inbox, UserPlus, Sparkles, ChevronRight, Power, Users,
+  Plus, Minus, Maximize2, Crown, Inbox, UserPlus, Sparkles, ChevronRight, Power, Users, Store,
 } from 'lucide-react';
+import TemplateMarket, { MarketTmpl } from './TemplateMarket';
 
 /*
  * Office — 「办公室」（data-id="office"）。
@@ -141,6 +142,7 @@ export default function Office() {
   ]);
   const [candidates, setCandidates] = useState<Cand[]>(INIT_CANDIDATES);
   const [rosterOpen, setRosterOpen] = useState(true);
+  const [marketOpen, setMarketOpen] = useState(false);
   const idSeq = useRef(20);
   const seq = useRef(2);
   const chatRef = useRef<HTMLDivElement>(null);
@@ -225,11 +227,13 @@ export default function Office() {
     setWorkers((prev) => [...prev, makeWorker(c.id, c.name, c.role, c.emoji, c.accent, c.model, prev.length, c.script)]);
     push({ kind: 'note', text: `已加入并启用 ${c.name}（${c.id}）` });
   };
-  const createFromTemplate = (t: Tmpl) => {
+  const spawn = (name: string, role: string, emoji: string, accent: string, model: string, note: string) => {
     const id = `w-100${idSeq.current++}`;
-    setWorkers((prev) => [...prev, makeWorker(id, t.name, t.role, t.emoji, t.accent, t.model, prev.length, t.script)]);
-    push({ kind: 'note', text: `已按模版「${t.name}」创建 ${id}` });
+    setWorkers((prev) => [...prev, makeWorker(id, name, role, emoji, accent, model, prev.length, GENERIC_SCRIPT)]);
+    push({ kind: 'note', text: `${note} ${id}` });
   };
+  const createFromTemplate = (t: Tmpl) => spawn(t.name, t.role, t.emoji, t.accent, t.model, `已按模版「${t.name}」创建`);
+  const pickFromMarket = (t: MarketTmpl) => spawn(t.name, t.role, t.emoji, t.accent, t.model, `已从模版市场添加「${t.name}」`);
   const canSend = text.trim() && (mode === 'broadcast' || !!target);
 
   return (
@@ -335,7 +339,10 @@ export default function Office() {
               )}
             </section>
             <section data-id="office-roster-templates">
-              <div className="mb-2 flex items-center gap-1.5 px-1 text-[11px] font-medium uppercase tracking-wide text-zinc-600"><Sparkles className="h-3 w-3" /> 模版 · 点击创建<span className="ml-auto normal-case text-zinc-700">{TEMPLATES.length}</span></div>
+              <div className="mb-2 flex items-center gap-1.5 px-1 text-[11px] font-medium uppercase tracking-wide text-zinc-600">
+                <Sparkles className="h-3 w-3" /> 模版
+                <button data-id="office-open-market" onClick={() => setMarketOpen(true)} className="ml-auto inline-flex items-center gap-1 rounded-md bg-sky-500/15 px-1.5 py-0.5 text-[10.5px] normal-case text-sky-300 transition-colors hover:bg-sky-500/25"><Store className="h-3 w-3" /> 模版市场</button>
+              </div>
               <div className="space-y-1.5">
                 {TEMPLATES.map((t) => (
                   <div key={t.key} data-id={`office-tmpl-${t.key}`} className="flex items-center gap-2.5 rounded-xl border border-dashed border-white/[0.09] bg-white/[0.015] px-2.5 py-2">
@@ -353,6 +360,8 @@ export default function Office() {
           className="absolute right-0 top-1/2 z-30 flex -translate-y-1/2 items-center gap-1.5 rounded-l-lg border border-r-0 border-white/10 bg-[#16161a]/90 px-2 py-3 text-[11px] text-zinc-400 backdrop-blur transition-colors hover:text-zinc-100"
           style={{ writingMode: 'vertical-rl' }}><Users className="h-3.5 w-3.5" /> 成员库</button>
       )}
+
+      <TemplateMarket open={marketOpen} onClose={() => setMarketOpen(false)} onPick={pickFromMarket} />
     </div>
   );
 }

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -1,0 +1,344 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, CircleDot, MessageSquare,
+} from 'lucide-react';
+
+/*
+ * Office — 「办公室」（data-id="office"）。
+ * 左栏：命令对话（上=history，下=prompt，自动 @ 选中的 worker，可广播）。
+ * 右侧：所有 worker 的 chat window，整齐网格，只显示 thinking + text（不拉 tool 结果）。
+ * 头像 = 各 agent 的 avatar。纯 UI 原型，mock 实时流（先不接接口）。
+ */
+
+type LineType = 'thinking' | 'text';
+interface Line { t: LineType; s: string }
+type Status = 'idle' | 'working' | 'done';
+
+interface Worker {
+  id: string;
+  name: string;
+  role: string;
+  emoji: string;       // avatar 占位（接接口后换成 agent 真实 avatar）
+  accent: string;
+  status: Status;
+  script: Line[];
+  shown: number;
+}
+
+type ChatKind = 'you' | 'dispatch' | 'broadcast' | 'done' | 'note';
+interface ChatMsg { id: number; kind: ChatKind; from?: string; to?: string; text: string; ts: string }
+
+const SELF = 'w-10001';
+
+const W = (id: string, name: string, role: string, emoji: string, accent: string, status: Status, script: Line[]): Worker =>
+  ({ id, name, role, emoji, accent, status, script, shown: status === 'working' ? 0 : script.length });
+
+const INIT_WORKERS: Worker[] = [
+  W('w-10010', '架构师 Aria', 'dev-senior', '🏛️', 'sky', 'working', [
+    { t: 'thinking', s: '把"画布"拆成 3 张卡：数据层 / 渲染层 / 画布层。' },
+    { t: 'text', s: '定义 LiteAgentCard props + digest 端点契约。' },
+    { t: 'thinking', s: 'tool_result 不传，payload 小一个数量级。' },
+    { t: 'text', s: '接口写进 docs，交给 Finn。' },
+    { t: 'text', s: '✅ 完成：技术任务卡 + 接口契约。' },
+  ]),
+  W('w-10011', '前端 Finn', 'dev-junior', '🎨', 'violet', 'working', [
+    { t: 'thinking', s: '复用 normalize，搭 worker window 网格。' },
+    { t: 'text', s: '左栏命令对话 + 右栏 window grid。' },
+    { t: 'thinking', s: '选中 window → prompt 自动 @ 它。' },
+    { t: 'text', s: 'window 加宽、对齐网格。' },
+    { t: 'text', s: '✅ 完成：办公室双栏布局。' },
+  ]),
+  W('w-10012', '测试 Quinn', 'qa', '🧪', 'emerald', 'working', [
+    { t: 'thinking', s: '核对验收标准：N window 同屏不卡。' },
+    { t: 'text', s: '跑 20 window 压力，盯帧率。' },
+    { t: 'thinking', s: 'thinking 太长要截断。' },
+    { t: 'text', s: 'FAIL：离屏 window 仍在轮询，需门控。' },
+  ]),
+  W('w-10013', '运维 Ops', 'ops', '🚀', 'orange', 'idle', [
+    { t: 'text', s: '待构建产物，准备部署。' },
+  ]),
+  W('w-10014', '安全 Sage', 'reviewer', '🛡️', 'rose', 'working', [
+    { t: 'thinking', s: '扫一遍有没有把 token 渲进 window。' },
+    { t: 'text', s: 'text+thinking 不含工具入参，攻击面更小。' },
+    { t: 'text', s: '✅ 完成：安全结论 PASS。' },
+  ]),
+];
+
+const ACCENT: Record<string, { grad: string; ring: string; chip: string; dot: string }> = {
+  sky:     { grad: 'from-sky-500/40 to-sky-700/20',         ring: 'ring-sky-400/40',     chip: 'bg-sky-500/15 text-sky-300',       dot: 'text-sky-400' },
+  violet:  { grad: 'from-violet-500/40 to-violet-700/20',   ring: 'ring-violet-400/40',  chip: 'bg-violet-500/15 text-violet-300', dot: 'text-violet-400' },
+  emerald: { grad: 'from-emerald-500/40 to-emerald-700/20', ring: 'ring-emerald-400/40', chip: 'bg-emerald-500/15 text-emerald-300', dot: 'text-emerald-400' },
+  orange:  { grad: 'from-orange-500/40 to-orange-700/20',   ring: 'ring-orange-400/40',  chip: 'bg-orange-500/15 text-orange-300', dot: 'text-orange-400' },
+  rose:    { grad: 'from-rose-500/40 to-rose-700/20',       ring: 'ring-rose-400/40',    chip: 'bg-rose-500/15 text-rose-300',     dot: 'text-rose-400' },
+};
+
+const STATUS_META: Record<Status, { label: string; cls: string }> = {
+  idle:    { label: '空闲',   cls: 'text-zinc-500' },
+  working: { label: '工作中', cls: 'text-amber-300' },
+  done:    { label: '完成',   cls: 'text-emerald-300' },
+};
+
+function nowStamp(): string {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+function Avatar({ emoji, accent, size = 28 }: { emoji: string; accent: string; size?: number }) {
+  const acc = ACCENT[accent] ?? ACCENT.sky;
+  return (
+    <span className={`grid shrink-0 place-items-center rounded-full bg-gradient-to-br ${acc.grad} ring-1 ring-white/10`}
+      style={{ width: size, height: size, fontSize: size * 0.5 }}>{emoji}</span>
+  );
+}
+
+export default function Office() {
+  const [workers, setWorkers] = useState<Worker[]>(INIT_WORKERS);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [mode, setMode] = useState<'single' | 'broadcast'>('single');
+  const [text, setText] = useState('');
+  const [mentionOpen, setMentionOpen] = useState(false);
+  const [chat, setChat] = useState<ChatMsg[]>([
+    { id: 1, kind: 'note', text: '办公室就绪。点右侧某个 worker 自动 @ 他派任务；或切广播对全体喊话。', ts: nowStamp() },
+  ]);
+  const seq = useRef(2);
+  const chatRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  const byId = useMemo(() => Object.fromEntries(workers.map((w) => [w.id, w])), [workers]);
+  const target = selectedId ? byId[selectedId] : null;
+
+  // mock 实时流
+  useEffect(() => {
+    const t = window.setInterval(() => {
+      setWorkers((prev) => prev.map((w) => {
+        if (w.status === 'working') {
+          if (w.shown < w.script.length) return { ...w, shown: w.shown + 1 };
+          return { ...w, status: 'done' };
+        }
+        if (w.status === 'done' && Math.random() < 0.1) return { ...w, status: 'working', shown: 0 };
+        return w;
+      }));
+    }, 1200);
+    return () => window.clearInterval(t);
+  }, []);
+
+  useEffect(() => {
+    const n = chatRef.current;
+    if (n) n.scrollTop = n.scrollHeight;
+  }, [chat]);
+
+  const push = (m: Omit<ChatMsg, 'id' | 'ts'>) => setChat((c) => [...c, { id: seq.current++, ts: nowStamp(), ...m }]);
+
+  const selectWorker = (w: Worker) => {
+    setSelectedId(w.id);
+    setMode('single');
+    setMentionOpen(false);
+    inputRef.current?.focus();
+  };
+
+  const simulateDone = (who: string, t = '✅ work done') => {
+    window.setTimeout(() => {
+      push({ kind: 'done', from: who, text: t });
+      setWorkers((prev) => prev.map((w) => (w.id === who ? { ...w, status: 'done' } : w)));
+    }, 2600);
+  };
+
+  const send = () => {
+    const body = text.trim();
+    if (!body) return;
+    if (mode === 'broadcast') {
+      push({ kind: 'broadcast', text: body });
+      setText('');
+      return;
+    }
+    if (!target) return;
+    push({ kind: 'dispatch', to: target.id, text: body });
+    setWorkers((prev) => prev.map((w) => (w.id === target.id ? { ...w, status: 'working', shown: 0 } : w)));
+    setText('');
+    simulateDone(target.id);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); }
+  };
+  const onChange = (v: string) => {
+    setText(v);
+    if (mode === 'single') setMentionOpen(/(^|\s)@$/.test(v));
+  };
+  const pickMention = (w: Worker) => {
+    setSelectedId(w.id); setMode('single');
+    setText((v) => v.replace(/@$/, ''));
+    setMentionOpen(false);
+    inputRef.current?.focus();
+  };
+
+  const canSend = text.trim() && (mode === 'broadcast' || !!target);
+
+  return (
+    <div data-id="office" className="absolute inset-0 flex bg-[#0A0A0A] text-zinc-300">
+      {/* 左栏：命令对话 */}
+      <aside data-id="office-command" className="flex w-[336px] min-w-[336px] shrink-0 flex-col border-r border-[var(--vsc-border)] bg-[#0c0c0c]">
+        <div className="flex h-12 shrink-0 items-center gap-2 border-b border-[var(--vsc-border)] px-4">
+          <Building2 className="h-4 w-4 text-sky-400" />
+          <span className="text-sm font-semibold text-zinc-100">办公室</span>
+          <span className="text-[11px] text-zinc-500">· 总控 {SELF}</span>
+        </div>
+
+        {/* history */}
+        <div ref={chatRef} data-id="office-command-history" className="flex-1 space-y-2.5 overflow-auto px-3 py-3">
+          {chat.map((m) => <CommandMsg key={m.id} m={m} byId={byId} />)}
+        </div>
+
+        {/* prompt */}
+        <div data-id="office-command-prompt" className="shrink-0 border-t border-[var(--vsc-border)] bg-[#0d0d0d] px-3 py-3">
+          <div className="relative">
+            <div data-id="office-mode" className="mb-2 inline-flex items-center gap-1 rounded-lg bg-white/[0.04] p-0.5 text-[12px]">
+              <button data-id="office-mode-single" onClick={() => setMode('single')}
+                className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'single' ? 'bg-white/10 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}`}>
+                <MessageSquare className="h-3.5 w-3.5" /> 单聊
+              </button>
+              <button data-id="office-mode-broadcast" onClick={() => { setMode('broadcast'); setMentionOpen(false); }}
+                className={`inline-flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'broadcast' ? 'bg-amber-500/20 text-amber-200' : 'text-zinc-500 hover:text-zinc-300'}`}>
+                <Megaphone className="h-3.5 w-3.5" /> 广播
+              </button>
+            </div>
+
+            {mentionOpen && mode === 'single' && (
+              <div data-id="office-mention" className="absolute bottom-full left-0 mb-2 w-full overflow-hidden rounded-xl border border-white/10 bg-[#141414] shadow-2xl">
+                {workers.map((w) => (
+                  <button key={w.id} data-id={`office-mention-${w.id}`} onClick={() => pickMention(w)}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-white/[0.06]">
+                    <Avatar emoji={w.emoji} accent={w.accent} size={22} />
+                    <span className="text-[13px] text-zinc-200">{w.name}</span>
+                    <span className="ml-auto font-mono text-[11px] text-zinc-500">{w.id}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+
+            <div data-id="office-target" className="mb-2 flex items-center gap-1.5">
+              {mode === 'broadcast' ? (
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-2.5 py-1 text-[12px] text-amber-200">
+                  <Megaphone className="h-3 w-3" /> 广播 · 全体（{workers.length}）
+                </span>
+              ) : target ? (
+                <span className="inline-flex items-center gap-1.5 rounded-full bg-sky-500/15 py-1 pl-1.5 pr-1.5 text-[12px] text-sky-300">
+                  <Avatar emoji={target.emoji} accent={target.accent} size={18} />
+                  <span className="font-mono">{target.id}</span>
+                  <button data-id="office-target-clear" onClick={() => setSelectedId(null)} className="rounded-full p-0.5 hover:bg-white/10"><X className="h-3 w-3" /></button>
+                </span>
+              ) : (
+                <span className="text-[12px] text-zinc-600">点右侧 worker，或 @ 选择</span>
+              )}
+            </div>
+
+            <div className="flex items-end gap-2 rounded-xl border border-white/10 bg-[#111] px-3 py-2 focus-within:border-white/20">
+              <textarea ref={inputRef} data-id="office-input" rows={1} value={text}
+                onChange={(e) => onChange(e.target.value)} onKeyDown={onKeyDown}
+                placeholder={mode === 'broadcast' ? '向全体广播…（Enter）' : target ? `给 ${target.name} 派任务…（Enter）` : '@ 选择 worker…'}
+                className="max-h-40 min-h-[24px] flex-1 resize-none bg-transparent text-[13px] leading-6 text-zinc-200 outline-none placeholder:text-zinc-600" />
+              <button data-id="office-send" onClick={send} disabled={!canSend}
+                className={`grid h-8 w-8 shrink-0 place-items-center rounded-lg text-white transition-colors disabled:cursor-not-allowed disabled:bg-white/[0.06] disabled:text-zinc-600 ${mode === 'broadcast' ? 'bg-amber-500/90 hover:bg-amber-400' : 'bg-sky-500/90 hover:bg-sky-400'}`}>
+                {mode === 'broadcast' ? <Megaphone className="h-4 w-4" /> : <Send className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+        </div>
+      </aside>
+
+      {/* 右侧：worker chat window 网格 */}
+      <main data-id="office-windows" className="min-w-0 flex-1 overflow-auto bg-[#080808] p-4">
+        <div className="mb-3 flex items-center gap-2 text-[11px] text-zinc-500">
+          <span className="rounded-md bg-white/[0.04] px-2 py-1">{workers.length} 个 worker</span>
+          <span className="rounded-md bg-white/[0.03] px-2 py-1 text-zinc-600">只显示 thinking + text · tool 结果不拉</span>
+        </div>
+        <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(360px, 1fr))' }}>
+          {workers.map((w) => (
+            <WorkerWindow key={w.id} w={w} selected={selectedId === w.id} onSelect={() => selectWorker(w)} />
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function CommandMsg({ m, byId }: { m: ChatMsg; byId: Record<string, Worker> }) {
+  if (m.kind === 'note') {
+    return <div data-id={`office-msg-${m.id}`} className="text-center text-[11.5px] leading-relaxed text-zinc-600">{m.text}</div>;
+  }
+  if (m.kind === 'broadcast') {
+    return (
+      <div data-id={`office-msg-${m.id}`} className="rounded-lg border border-amber-500/20 bg-amber-500/[0.06] px-2.5 py-1.5 text-[12.5px] text-amber-50/90">
+        <span className="mr-1 text-[11px] text-amber-300/80">📢 广播 · 全体</span>
+        <div className="whitespace-pre-wrap">{m.text}</div>
+      </div>
+    );
+  }
+  if (m.kind === 'dispatch') {
+    const w = m.to ? byId[m.to] : null;
+    return (
+      <div data-id={`office-msg-${m.id}`} className="flex flex-col items-end gap-0.5">
+        <div className="flex items-center gap-1 text-[11px] text-zinc-500">
+          <AtSign className="h-3 w-3" /><span className="font-mono">{m.to}</span>{w && <span>{w.name}</span>}
+        </div>
+        <div className="max-w-[88%] rounded-lg rounded-tr-sm bg-sky-500/15 px-2.5 py-1.5 text-[12.5px] text-sky-100 whitespace-pre-wrap">{m.text}</div>
+      </div>
+    );
+  }
+  // done
+  const w = m.from ? byId[m.from] : null;
+  return (
+    <div data-id={`office-msg-${m.id}`} className="flex items-center gap-1.5">
+      {w && <Avatar emoji={w.emoji} accent={w.accent} size={20} />}
+      <span className="inline-flex items-center gap-1 rounded-lg bg-emerald-500/10 px-2 py-1 text-[12px] text-emerald-300">
+        <CheckCircle2 className="h-3.5 w-3.5" /> {m.text}
+      </span>
+      <span className="ml-auto text-[10px] text-zinc-700">{m.ts}</span>
+    </div>
+  );
+}
+
+function WorkerWindow({ w, selected, onSelect }: { w: Worker; selected: boolean; onSelect: () => void }) {
+  const acc = ACCENT[w.accent] ?? ACCENT.sky;
+  const st = STATUS_META[w.status];
+  const lines = w.script.slice(0, w.shown).slice(-10);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  useEffect(() => { const n = bodyRef.current; if (n) n.scrollTop = n.scrollHeight; }, [w.shown]);
+
+  return (
+    <button
+      data-id={`office-window-${w.id}`}
+      onClick={onSelect}
+      className={`flex h-[260px] flex-col overflow-hidden rounded-xl border bg-[#0e0e0e] text-left transition-colors ${selected ? `ring-2 ${acc.ring} border-transparent` : 'border-white/[0.07] hover:border-white/15'}`}
+    >
+      <div data-id={`office-window-header-${w.id}`} className="flex shrink-0 items-center gap-2 border-b border-white/[0.06] bg-white/[0.02] px-3 py-2">
+        <Avatar emoji={w.emoji} accent={w.accent} size={30} />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[13px] font-medium text-zinc-200">{w.name}</span>
+          <span className="font-mono text-[10.5px] text-zinc-500">{w.id} · {w.role}</span>
+        </span>
+        <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10.5px] ${acc.chip}`}>
+          {w.status === 'working' ? <Loader2 className="h-3 w-3 animate-spin" /> :
+           w.status === 'done' ? <CheckCircle2 className="h-3 w-3" /> :
+           <CircleDot className={`h-3 w-3 ${acc.dot}`} />}
+          {st.label}
+        </span>
+      </div>
+
+      <div ref={bodyRef} data-id={`office-window-body-${w.id}`} className="flex-1 space-y-1.5 overflow-auto px-3 py-2">
+        {lines.length === 0 ? (
+          <div className="text-[11.5px] text-zinc-600">待派活…</div>
+        ) : lines.map((ln, i) => (
+          ln.t === 'thinking'
+            ? <div key={i} className="border-l-2 border-amber-300/25 pl-2 text-[11.5px] leading-relaxed text-amber-50/55">{ln.s}</div>
+            : <div key={i} className="text-[12px] leading-relaxed text-zinc-300">{ln.s}</div>
+        ))}
+      </div>
+
+      {w.status === 'done' && (
+        <div className="shrink-0 border-t border-emerald-500/15 bg-emerald-500/[0.06] px-3 py-1 text-[10.5px] text-emerald-300/90">✅ work done · 等总控验收</div>
+      )}
+    </button>
+  );
+}

--- a/app/src/components/office/Office.tsx
+++ b/app/src/components/office/Office.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Building2, Send, Megaphone, AtSign, X, Loader2, CheckCircle2, MessageSquare,
-  Plus, Minus, Maximize2, Crown, Inbox, UserPlus, Sparkles, ChevronRight, Power, Users, Store,
+  Plus, Minus, Maximize2, Crown, Inbox, UserPlus, ChevronRight, Power, Users, Store,
 } from 'lucide-react';
 import TemplateMarket, { MarketTmpl } from './TemplateMarket';
 
@@ -95,8 +95,6 @@ function Avatar({ emoji, accent, size = 30, status }: { emoji: string; accent: s
 
 /* ── 候选成员（存在但未加入/未开启 = 离线）── */
 interface Cand { id: string; name: string; role: string; emoji: string; accent: string; model: string; script: Line[] }
-/* ── 模版成员（我们提供的角色预设，点击按模版创建新成员）── */
-interface Tmpl { key: string; name: string; role: string; emoji: string; accent: string; model: string; script: Line[] }
 
 const GENERIC_SCRIPT: Line[] = [
   { t: 'thinking', s: '读取任务卡与验收标准…' },
@@ -109,15 +107,6 @@ const INIT_CANDIDATES: Cand[] = [
   { id: 'w-10015', name: '文案 Wendy', role: 'writer', emoji: '✍️', accent: 'violet', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
   { id: 'w-10016', name: '数据 Dана', role: 'analyst', emoji: '📊', accent: 'sky', model: 'gpt-5.5', script: GENERIC_SCRIPT },
   { id: 'w-10017', name: '设计 Deo', role: 'designer', emoji: '🎭', accent: 'rose', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
-];
-
-const TEMPLATES: Tmpl[] = [
-  { key: 'arch', name: '架构师', role: 'dev-senior', emoji: '🏛️', accent: 'sky', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
-  { key: 'be', name: '后端开发', role: 'dev', emoji: '🛠️', accent: 'violet', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
-  { key: 'fe', name: '前端开发', role: 'dev-junior', emoji: '🎨', accent: 'violet', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
-  { key: 'qa', name: '测试', role: 'qa', emoji: '🧪', accent: 'emerald', model: 'gpt-5.5', script: GENERIC_SCRIPT },
-  { key: 'ops', name: '运维', role: 'ops', emoji: '🚀', accent: 'amber', model: 'deepseek-v4-pro', script: GENERIC_SCRIPT },
-  { key: 'sec', name: '安全', role: 'reviewer', emoji: '🛡️', accent: 'rose', model: 'claude-haiku-4-5', script: GENERIC_SCRIPT },
 ];
 
 function makeWorker(id: string, name: string, role: string, emoji: string, accent: string, model: string, slot: number, script: Line[]): Worker {
@@ -232,7 +221,6 @@ export default function Office() {
     setWorkers((prev) => [...prev, makeWorker(id, name, role, emoji, accent, model, prev.length, GENERIC_SCRIPT)]);
     push({ kind: 'note', text: `${note} ${id}` });
   };
-  const createFromTemplate = (t: Tmpl) => spawn(t.name, t.role, t.emoji, t.accent, t.model, `已按模版「${t.name}」创建`);
   const pickFromMarket = (t: MarketTmpl) => spawn(t.name, t.role, t.emoji, t.accent, t.model, `已从模版市场添加「${t.name}」`);
   const canSend = text.trim() && (mode === 'broadcast' || !!target);
 
@@ -338,21 +326,15 @@ export default function Office() {
                 </div>
               )}
             </section>
-            <section data-id="office-roster-templates">
-              <div className="mb-2 flex items-center gap-1.5 px-1 text-[11px] font-medium uppercase tracking-wide text-zinc-600">
-                <Sparkles className="h-3 w-3" /> 模版
-                <button data-id="office-open-market" onClick={() => setMarketOpen(true)} className="ml-auto inline-flex items-center gap-1 rounded-md bg-sky-500/15 px-1.5 py-0.5 text-[10.5px] normal-case text-sky-300 transition-colors hover:bg-sky-500/25"><Store className="h-3 w-3" /> 模版市场</button>
-              </div>
-              <div className="space-y-1.5">
-                {TEMPLATES.map((t) => (
-                  <div key={t.key} data-id={`office-tmpl-${t.key}`} className="flex items-center gap-2.5 rounded-xl border border-dashed border-white/[0.09] bg-white/[0.015] px-2.5 py-2">
-                    <Avatar emoji={t.emoji} accent={t.accent} size={28} />
-                    <span className="min-w-0 flex-1"><span className="block truncate text-[12.5px] text-zinc-300">{t.name}</span><span className="block truncate text-[10.5px] text-zinc-600">{t.role}</span></span>
-                    <button data-id={`office-tmpl-create-${t.key}`} onClick={() => createFromTemplate(t)} className="inline-flex items-center gap-1 rounded-lg bg-sky-500/15 px-2 py-1 text-[11.5px] text-sky-300 transition-colors hover:bg-sky-500/25"><Plus className="h-3.5 w-3.5" /> 创建</button>
-                  </div>
-                ))}
-              </div>
-            </section>
+            <button data-id="office-open-market" onClick={() => setMarketOpen(true)}
+              className="flex w-full items-center gap-3 rounded-xl border border-sky-400/20 bg-sky-500/10 px-3 py-3 text-left transition-colors hover:border-sky-400/40 hover:bg-sky-500/15">
+              <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-sky-500/20 text-sky-300"><Store className="h-5 w-5" /></span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-[13px] font-medium text-zinc-100">Agent 模版市场</span>
+                <span className="block text-[11px] text-zinc-500">浏览各行各业的预置 agent</span>
+              </span>
+              <ChevronRight className="h-4 w-4 text-zinc-500" />
+            </button>
           </div>
         </aside>
       ) : (

--- a/app/src/components/office/TemplateMarket.tsx
+++ b/app/src/components/office/TemplateMarket.tsx
@@ -1,18 +1,20 @@
 import { useMemo, useState } from 'react';
 import {
   X, Search, Check, Plus, LayoutGrid, Code2, PenTool, BarChart3, Megaphone,
-  ShoppingCart, Palette, Briefcase, Headphones, Store,
+  ShoppingCart, Palette, Briefcase, Headphones, Store, Users, Sparkles,
 } from 'lucide-react';
 
 /*
- * TemplateMarket —「Agent 模版市场」全屏大屏（data-id="template-market"）。
- * 各行各业的预置 agent 模版，按分类浏览 / 搜索 / 一键添加到办公室。
- * 纯 UI 原型；onPick 把选中模版交给 Office 在画布上创建成员。
+ * TemplateMarket —「Agent & 团队 市场」全屏大屏（data-id="template-market"）。
+ * 两个视图：团队（一键组建整支班子）/ 单个 Agent（各行各业角色模版）。
+ * 纯 UI 原型；onPick 加单个 agent，onPickTeam 加整支团队，由 Office 在画布上创建。
  */
 
 export interface MarketTmpl { key: string; cat: string; name: string; role: string; emoji: string; accent: string; model: string; desc: string; tags: string[] }
+export interface TeamMember { name: string; role: string; emoji: string; accent: string; model: string }
+export interface TeamTmpl { key: string; cat: string; name: string; emoji: string; accent: string; desc: string; tags: string[]; members: TeamMember[] }
 
-const CATEGORIES: { key: string; name: string; icon: any }[] = [
+const AGENT_CATS: { key: string; name: string; icon: any }[] = [
   { key: 'all', name: '全部', icon: LayoutGrid },
   { key: 'dev', name: '软件研发', icon: Code2 },
   { key: 'content', name: '内容创作', icon: PenTool },
@@ -23,160 +25,268 @@ const CATEGORIES: { key: string; name: string; icon: any }[] = [
   { key: 'biz', name: '商业职能', icon: Briefcase },
   { key: 'cs', name: '客服支持', icon: Headphones },
 ];
+const TEAM_CATS: { key: string; name: string; icon: any }[] = [
+  { key: 'all', name: '全部', icon: LayoutGrid },
+  { key: 'creative', name: '创意内容', icon: PenTool },
+  { key: 'software', name: '软件研发', icon: Code2 },
+  { key: 'marketing', name: '营销增长', icon: Megaphone },
+  { key: 'ecom', name: '电商运营', icon: ShoppingCart },
+  { key: 'data', name: '数据智能', icon: BarChart3 },
+];
 
 const GRAD: Record<string, string> = {
   sky: 'from-sky-500/45 to-sky-700/15', violet: 'from-violet-500/45 to-violet-700/15',
   emerald: 'from-emerald-500/45 to-emerald-700/15', amber: 'from-amber-500/45 to-amber-700/15',
   rose: 'from-rose-500/45 to-rose-700/15',
 };
+const COVER: Record<string, string> = {
+  sky: 'from-sky-500/30 via-sky-600/10 to-transparent', violet: 'from-violet-500/30 via-violet-600/10 to-transparent',
+  emerald: 'from-emerald-500/30 via-emerald-600/10 to-transparent', amber: 'from-amber-500/30 via-amber-600/10 to-transparent',
+  rose: 'from-rose-500/30 via-rose-600/10 to-transparent',
+};
 
 const T = (key: string, cat: string, name: string, role: string, emoji: string, accent: string, model: string, desc: string, tags: string[]): MarketTmpl =>
   ({ key, cat, name, role, emoji, accent, model, desc, tags });
+const M = (name: string, role: string, emoji: string, accent: string, model = 'deepseek-v4-pro'): TeamMember => ({ name, role, emoji, accent, model });
 
 const MARKET: MarketTmpl[] = [
-  // 软件研发
   T('arch', 'dev', '架构师', 'dev-senior', '🏛️', 'sky', 'deepseek-v4-pro', '拆解需求、定义接口与目录结构、做关键技术选型并把关 review。', ['架构', '选型', 'review']),
   T('fe', 'dev', '前端工程师', 'dev-junior', '🎨', 'sky', 'deepseek-v4-pro', '实现页面与组件，关注交互细节、可访问性与性能。', ['React', 'UI', 'a11y']),
   T('be', 'dev', '后端工程师', 'dev', '🛠️', 'sky', 'deepseek-v4-pro', 'API 设计、数据库与服务端逻辑，保证一致性与性能。', ['API', 'DB', '服务']),
   T('qa', 'dev', '测试工程师', 'qa', '🧪', 'sky', 'gpt-5.5', '编写/执行用例、跑回归、核对验收标准并出 PASS/FAIL。', ['测试', '回归', '验收']),
   T('ops', 'dev', 'DevOps', 'ops', '🚀', 'sky', 'deepseek-v4-pro', '构建、部署、发布与回滚，线上监控与告警。', ['CI/CD', '部署', '监控']),
   T('sec', 'dev', '安全工程师', 'reviewer', '🛡️', 'sky', 'claude-haiku-4-5', '密钥/注入/权限/依赖风险审查，出安全结论。', ['安全', '审计']),
-  // 内容创作
   T('copy', 'content', '文案策划', 'writer', '✍️', 'violet', 'deepseek-v4-pro', '营销文案、卖点提炼、不同渠道的语气适配。', ['文案', '营销']),
   T('script', 'content', '短视频编剧', 'scriptwriter', '🎬', 'violet', 'gpt-5.5', '脚本、分镜、开头钩子与节奏设计。', ['脚本', '短视频']),
   T('seo', 'content', 'SEO 编辑', 'seo', '🔍', 'violet', 'deepseek-v4-pro', '关键词与长尾布局、内容结构优化。', ['SEO', '内容']),
   T('trans', 'content', '翻译/本地化', 'translator', '🌐', 'violet', 'deepseek-v4-pro', '多语翻译与本地化，保留语气与术语一致。', ['翻译', 'i18n']),
   T('media', 'content', '新媒体运营', 'editor', '📣', 'violet', 'deepseek-v4-pro', '选题、排版、推送与互动追踪。', ['新媒体', '排版']),
-  // 数据分析
   T('analyst', 'data', '数据分析师', 'analyst', '📊', 'emerald', 'gpt-5.5', '指标体系、报表与可执行洞察。', ['SQL', '报表', '洞察']),
   T('bi', 'data', 'BI 工程师', 'bi', '📈', 'emerald', 'deepseek-v4-pro', '看板搭建与数据可视化。', ['BI', '可视化']),
   T('de', 'data', '数据工程', 'data-eng', '🗄️', 'emerald', 'deepseek-v4-pro', '数据管道、清洗与数仓建模。', ['ETL', '数仓']),
   T('ml', 'data', 'ML 工程师', 'ml', '🤖', 'emerald', 'gpt-5.5', '特征、建模、训练与评估。', ['ML', '建模']),
-  // 市场营销
   T('growth', 'mkt', '增长黑客', 'growth', '📈', 'amber', 'gpt-5.5', '增长实验设计、漏斗分析与迭代。', ['增长', '实验']),
   T('ads', 'mkt', '投放优化', 'ads', '🎯', 'amber', 'deepseek-v4-pro', '广告投放策略与 ROI 优化。', ['投放', 'ROI']),
   T('social', 'mkt', '社媒运营', 'social', '💬', 'amber', 'deepseek-v4-pro', '内容日历、互动与社群运营。', ['社媒', '运营']),
   T('brand', 'mkt', '品牌策划', 'brand', '✨', 'amber', 'deepseek-v4-pro', '品牌定位、叙事与视觉调性。', ['品牌', '叙事']),
-  // 电商运营
   T('shop', 'ecom', '店铺运营', 'ecom', '🛒', 'rose', 'deepseek-v4-pro', '上架、活动排期与数据复盘。', ['电商', '运营']),
   T('sel', 'ecom', '选品分析', 'selection', '🔎', 'rose', 'gpt-5.5', '选品、趋势与利润测算。', ['选品', '趋势']),
   T('detail', 'ecom', '详情页文案', 'writer', '🏷️', 'rose', 'deepseek-v4-pro', '详情页结构与卖点转化。', ['详情页', '转化']),
   T('after', 'ecom', '售后助理', 'cs', '📦', 'rose', 'deepseek-v4-pro', '退换货、纠纷与售后流程。', ['售后', '工单']),
-  // 设计创意
   T('ui', 'design', 'UI 设计', 'ui-design', '🖌️', 'violet', 'deepseek-v4-pro', '界面设计与组件规范。', ['UI', '规范']),
   T('graphic', 'design', '平面设计', 'graphic', '🎨', 'violet', 'deepseek-v4-pro', '海报、物料与视觉输出。', ['平面', '物料']),
   T('illus', 'design', '插画师', 'illustrator', '🖼️', 'violet', 'deepseek-v4-pro', '插画风格与配图。', ['插画', '风格']),
-  T('vi', 'design', '品牌设计', 'brand-design', '🅰️', 'violet', 'deepseek-v4-pro', 'VI 系统与 logo 设计。', ['VI', 'logo']),
-  // 商业职能
   T('pm', 'biz', '产品经理', 'pm', '📋', 'sky', 'gpt-5.5', '需求梳理、PRD 与优先级排布。', ['PRD', '需求']),
   T('pmo', 'biz', '项目经理', 'pmo', '🗂️', 'sky', 'deepseek-v4-pro', '排期、风险与跨角色协调。', ['排期', '风险']),
   T('fin', 'biz', '财务分析', 'finance', '💰', 'sky', 'gpt-5.5', '预算、报表与商业测算。', ['财务', '测算']),
   T('legal', 'biz', '法务顾问', 'legal', '⚖️', 'sky', 'claude-haiku-4-5', '合同审阅、合规与风险提示。', ['合同', '合规']),
   T('hr', 'biz', 'HR 招聘', 'hr', '🧑‍💼', 'sky', 'deepseek-v4-pro', 'JD 撰写、简历筛选与面评。', ['招聘', 'JD']),
-  // 客服支持
   T('support', 'cs', '智能客服', 'support', '🎧', 'emerald', 'deepseek-v4-pro', '多轮答疑、FAQ 与转人工。', ['客服', 'FAQ']),
   T('triage', 'cs', '工单分类', 'triage', '🧭', 'emerald', 'gpt-5.5', '工单分类、优先级与路由。', ['工单', '路由']),
   T('kb', 'cs', '知识库维护', 'kb', '📚', 'emerald', 'deepseek-v4-pro', '知识沉淀、更新与检索。', ['KB', '检索']),
 ];
 
-export default function TemplateMarket({ open, onClose, onPick }: {
-  open: boolean; onClose: () => void; onPick: (t: MarketTmpl) => void;
+const TEAMS: TeamTmpl[] = [
+  {
+    key: 'comic', cat: 'creative', name: '漫剧创作团队', emoji: '🎬', accent: 'rose',
+    desc: '从剧本到成片的一条龙漫剧班子：编剧立骨、分镜定节奏、作画上色出成片。',
+    tags: ['漫剧', '剧本→成片', '6 工种'],
+    members: [
+      M('导演/监制', 'director', '🎬', 'rose'), M('编剧', 'screenwriter', '📝', 'rose'),
+      M('分镜师', 'storyboard', '🎞️', 'rose'), M('角色设定', 'char-design', '🧝', 'rose'),
+      M('作画', 'artist', '🖌️', 'rose'), M('上色/合成', 'colorist', '🎨', 'rose'),
+    ],
+  },
+  {
+    key: 'software', cat: 'software', name: '软件开发团队', emoji: '💻', accent: 'sky',
+    desc: '全生命周期研发班子：架构拆解、前后端实现、QA 验收、运维上线、安全把关。',
+    tags: ['全栈', '研发→上线', '6 工种'],
+    members: [
+      M('架构师', 'dev-senior', '🏛️', 'sky'), M('前端', 'dev-junior', '🎨', 'sky'),
+      M('后端', 'dev', '🛠️', 'sky'), M('测试', 'qa', '🧪', 'sky', 'gpt-5.5'),
+      M('DevOps', 'ops', '🚀', 'sky'), M('安全', 'reviewer', '🛡️', 'sky', 'claude-haiku-4-5'),
+    ],
+  },
+  {
+    key: 'marketing', cat: 'marketing', name: '内容营销团队', emoji: '📣', accent: 'amber',
+    desc: '从内容到增长：文案产出、SEO 与社媒分发、配图设计、数据复盘闭环。',
+    tags: ['内容', '增长', '5 工种'],
+    members: [
+      M('文案策划', 'writer', '✍️', 'amber'), M('SEO 编辑', 'seo', '🔍', 'amber'),
+      M('社媒运营', 'social', '💬', 'amber'), M('平面设计', 'graphic', '🎨', 'amber'),
+      M('数据分析', 'analyst', '📊', 'amber', 'gpt-5.5'),
+    ],
+  },
+  {
+    key: 'ecom', cat: 'ecom', name: '电商运营团队', emoji: '🛒', accent: 'violet',
+    desc: '开店到爆单：选品、店铺运营、详情页转化、投放拉新、客服售后。',
+    tags: ['电商', '选品→转化', '5 工种'],
+    members: [
+      M('店铺运营', 'ecom', '🛒', 'violet'), M('选品分析', 'selection', '🔎', 'violet', 'gpt-5.5'),
+      M('详情页文案', 'writer', '🏷️', 'violet'), M('投放优化', 'ads', '🎯', 'violet'),
+      M('客服', 'cs', '🎧', 'violet'),
+    ],
+  },
+  {
+    key: 'data', cat: 'data', name: '数据团队', emoji: '📊', accent: 'emerald',
+    desc: '数据全链路：管道与数仓、指标与看板、建模与预测。',
+    tags: ['数据', 'ETL→洞察', '4 工种'],
+    members: [
+      M('数据分析', 'analyst', '📊', 'emerald', 'gpt-5.5'), M('BI 工程', 'bi', '📈', 'emerald'),
+      M('数据工程', 'data-eng', '🗄️', 'emerald'), M('ML 工程', 'ml', '🤖', 'emerald', 'gpt-5.5'),
+    ],
+  },
+  {
+    key: 'shortvideo', cat: 'creative', name: '短视频团队', emoji: '🎥', accent: 'rose',
+    desc: '爆款短视频流水线：选题编导、脚本、剪辑文案、账号运营。',
+    tags: ['短视频', '选题→投放', '4 工种'],
+    members: [
+      M('编导', 'director', '🎬', 'rose'), M('编剧', 'scriptwriter', '📝', 'rose'),
+      M('剪辑文案', 'editor', '✂️', 'rose'), M('账号运营', 'social', '💬', 'rose'),
+    ],
+  },
+  {
+    key: 'startup', cat: 'software', name: '产品初创团队', emoji: '🚀', accent: 'sky',
+    desc: '0→1 精简班子：产品定方向、架构+全栈快速实现、设计与增长并进。',
+    tags: ['0→1', 'MVP', '5 工种'],
+    members: [
+      M('产品经理', 'pm', '📋', 'sky', 'gpt-5.5'), M('架构师', 'dev-senior', '🏛️', 'sky'),
+      M('全栈', 'dev', '🛠️', 'sky'), M('设计', 'ui-design', '🖌️', 'sky'),
+      M('增长', 'growth', '📈', 'sky', 'gpt-5.5'),
+    ],
+  },
+];
+
+export default function TemplateMarket({ open, onClose, onPick, onPickTeam }: {
+  open: boolean; onClose: () => void; onPick: (t: MarketTmpl) => void; onPickTeam: (t: TeamTmpl) => void;
 }) {
+  const [view, setView] = useState<'team' | 'agent'>('team');
   const [cat, setCat] = useState('all');
   const [q, setQ] = useState('');
   const [added, setAdded] = useState<Set<string>>(new Set());
+  const [builtTeams, setBuiltTeams] = useState<Set<string>>(new Set());
 
+  const cats = view === 'team' ? TEAM_CATS : AGENT_CATS;
   const counts = useMemo(() => {
-    const m: Record<string, number> = { all: MARKET.length };
-    for (const t of MARKET) m[t.cat] = (m[t.cat] || 0) + 1;
+    const items = view === 'team' ? TEAMS : MARKET;
+    const m: Record<string, number> = { all: items.length };
+    for (const t of items) m[t.cat] = (m[t.cat] || 0) + 1;
     return m;
-  }, []);
+  }, [view]);
 
-  const list = useMemo(() => {
+  const agents = useMemo(() => {
     const kw = q.trim().toLowerCase();
-    return MARKET.filter((t) => (cat === 'all' || t.cat === cat) &&
-      (!kw || t.name.toLowerCase().includes(kw) || t.role.toLowerCase().includes(kw) || t.desc.toLowerCase().includes(kw) || t.tags.some((x) => x.toLowerCase().includes(kw))));
+    return MARKET.filter((t) => (cat === 'all' || t.cat === cat) && (!kw || t.name.toLowerCase().includes(kw) || t.role.toLowerCase().includes(kw) || t.desc.toLowerCase().includes(kw) || t.tags.some((x) => x.toLowerCase().includes(kw))));
+  }, [cat, q]);
+  const teams = useMemo(() => {
+    const kw = q.trim().toLowerCase();
+    return TEAMS.filter((t) => (cat === 'all' || t.cat === cat) && (!kw || t.name.toLowerCase().includes(kw) || t.desc.toLowerCase().includes(kw) || t.tags.some((x) => x.toLowerCase().includes(kw)) || t.members.some((mm) => mm.name.toLowerCase().includes(kw))));
   }, [cat, q]);
 
   if (!open) return null;
-
-  const pick = (t: MarketTmpl) => { onPick(t); setAdded((s) => new Set(s).add(t.key)); };
+  const switchView = (v: 'team' | 'agent') => { setView(v); setCat('all'); setQ(''); };
+  const pickAgent = (t: MarketTmpl) => { onPick(t); setAdded((s) => new Set(s).add(t.key)); };
+  const buildTeam = (t: TeamTmpl) => { onPickTeam(t); setBuiltTeams((s) => new Set(s).add(t.key)); };
 
   return (
     <div data-id="template-market" className="absolute inset-0 z-[200] flex items-center justify-center bg-black/70 p-6 backdrop-blur-sm" onPointerDown={onClose}>
-      <div className="relative flex h-[88vh] w-[1120px] max-w-[96vw] overflow-hidden rounded-2xl border border-white/10 bg-[#0b0b0e] shadow-2xl" onPointerDown={(e) => e.stopPropagation()}>
+      <div className="relative flex h-[88vh] w-[1180px] max-w-[96vw] overflow-hidden rounded-2xl border border-white/10 bg-[#0b0b0e] shadow-2xl" onPointerDown={(e) => e.stopPropagation()}>
         {/* 左：分类 */}
         <aside data-id="market-cats" className="flex w-52 shrink-0 flex-col border-r border-white/[0.06] bg-[#0d0d10]">
-          <div className="flex items-center gap-2 px-4 py-4 text-zinc-100">
-            <Store className="h-5 w-5 text-sky-400" />
-            <span className="text-[14px] font-semibold">模版市场</span>
-          </div>
+          <div className="flex items-center gap-2 px-4 py-4 text-zinc-100"><Store className="h-5 w-5 text-sky-400" /><span className="text-[14px] font-semibold">市场</span></div>
           <div className="flex-1 space-y-0.5 overflow-auto px-2 pb-3">
-            {CATEGORIES.map((c) => {
+            {cats.map((c) => {
               const Icon = c.icon; const on = cat === c.key;
               return (
-                <button key={c.key} data-id={`market-cat-${c.key}`} onClick={() => setCat(c.key)}
-                  className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors ${on ? 'bg-white/[0.08] text-zinc-100' : 'text-zinc-400 hover:bg-white/[0.04] hover:text-zinc-200'}`}>
-                  <Icon className={`h-4 w-4 ${on ? 'text-sky-400' : 'text-zinc-500'}`} />
-                  <span className="flex-1">{c.name}</span>
-                  <span className="text-[11px] text-zinc-600">{counts[c.key] || 0}</span>
+                <button key={c.key} data-id={`market-cat-${c.key}`} onClick={() => setCat(c.key)} className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors ${on ? 'bg-white/[0.08] text-zinc-100' : 'text-zinc-400 hover:bg-white/[0.04] hover:text-zinc-200'}`}>
+                  <Icon className={`h-4 w-4 ${on ? 'text-sky-400' : 'text-zinc-500'}`} /><span className="flex-1">{c.name}</span><span className="text-[11px] text-zinc-600">{counts[c.key] || 0}</span>
                 </button>
               );
             })}
           </div>
         </aside>
 
-        {/* 右：标题 + 搜索 + 卡网格 */}
+        {/* 右 */}
         <div className="flex min-w-0 flex-1 flex-col">
           <header className="flex shrink-0 items-center gap-3 border-b border-white/[0.06] px-6 py-4">
-            <div className="min-w-0 flex-1">
-              <div className="text-[17px] font-semibold text-zinc-100">Agent 模版市场</div>
-              <div className="text-[12px] text-zinc-500">各行各业的预置 agent，一键加入你的办公室</div>
+            <div className="min-w-0">
+              <div className="text-[17px] font-semibold text-zinc-100">AI 团队 & Agent 市场</div>
+              <div className="text-[12px] text-zinc-500">{view === 'team' ? '一键组建整支团队，立刻开工' : '各行各业的预置 agent，按需添加'}</div>
             </div>
-            <div className="relative w-72 max-w-[40%]">
+            {/* 视图切换 */}
+            <div data-id="market-view" className="ml-3 inline-flex items-center gap-0.5 rounded-lg bg-white/[0.05] p-0.5 text-[12.5px]">
+              <button data-id="market-view-team" onClick={() => switchView('team')} className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 transition-colors ${view === 'team' ? 'bg-white/10 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}`}><Users className="h-3.5 w-3.5" /> 团队</button>
+              <button data-id="market-view-agent" onClick={() => switchView('agent')} className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 transition-colors ${view === 'agent' ? 'bg-white/10 text-zinc-100' : 'text-zinc-500 hover:text-zinc-300'}`}><Sparkles className="h-3.5 w-3.5" /> 单个 Agent</button>
+            </div>
+            <div className="relative ml-auto w-64 max-w-[34%]">
               <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500" />
-              <input data-id="market-search" value={q} onChange={(e) => setQ(e.target.value)} placeholder="搜索角色 / 技能 / 行业…"
-                className="w-full rounded-lg border border-white/10 bg-[#141418] py-2 pl-8 pr-3 text-[13px] text-zinc-200 outline-none placeholder:text-zinc-600 focus:border-white/25" />
+              <input data-id="market-search" value={q} onChange={(e) => setQ(e.target.value)} placeholder={view === 'team' ? '搜索团队 / 工种…' : '搜索角色 / 技能…'} className="w-full rounded-lg border border-white/10 bg-[#141418] py-2 pl-8 pr-3 text-[13px] text-zinc-200 outline-none placeholder:text-zinc-600 focus:border-white/25" />
             </div>
-            <button data-id="market-close" onClick={onClose} className="grid h-8 w-8 place-items-center rounded-lg text-zinc-500 hover:bg-white/10 hover:text-zinc-200"><X className="h-4.5 w-4.5" /></button>
+            <button data-id="market-close" onClick={onClose} className="grid h-8 w-8 place-items-center rounded-lg text-zinc-500 hover:bg-white/10 hover:text-zinc-200"><X className="h-4 w-4" /></button>
           </header>
 
-          <div data-id="market-grid" className="flex-1 overflow-auto px-6 py-5">
-            {list.length === 0 ? (
-              <div className="grid h-full place-items-center text-[13px] text-zinc-600">没有匹配的模版</div>
-            ) : (
-              <div className="grid gap-3.5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(248px, 1fr))' }}>
-                {list.map((t) => {
-                  const isAdded = added.has(t.key);
-                  return (
-                    <div key={t.key} data-id={`market-card-${t.key}`} className="group flex flex-col rounded-2xl border border-white/[0.07] bg-[#101014] p-3.5 transition-colors hover:border-white/15">
-                      <div className="mb-2 flex items-center gap-2.5">
-                        <span className={`grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-gradient-to-br ${GRAD[t.accent] ?? GRAD.sky} text-xl ring-1 ring-white/10`}>{t.emoji}</span>
-                        <div className="min-w-0">
-                          <div className="truncate text-[14px] font-semibold text-zinc-100">{t.name}</div>
-                          <div className="truncate font-mono text-[11px] text-zinc-500">{t.role}</div>
+          {view === 'team' ? (
+            <div data-id="market-team-grid" className="flex-1 overflow-auto px-6 py-5">
+              {teams.length === 0 ? <div className="grid h-full place-items-center text-[13px] text-zinc-600">没有匹配的团队</div> : (
+                <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}>
+                  {teams.map((t) => {
+                    const built = builtTeams.has(t.key);
+                    return (
+                      <div key={t.key} data-id={`market-team-${t.key}`} className="group flex flex-col overflow-hidden rounded-2xl border border-white/[0.08] bg-[#101014] transition-colors hover:border-white/20">
+                        <div className={`relative flex h-20 items-center gap-3 bg-gradient-to-r ${COVER[t.accent] ?? COVER.sky} px-4`}>
+                          <span className={`grid h-12 w-12 place-items-center rounded-xl bg-gradient-to-br ${GRAD[t.accent] ?? GRAD.sky} text-2xl ring-1 ring-white/15`}>{t.emoji}</span>
+                          <div className="min-w-0"><div className="truncate text-[15px] font-semibold text-zinc-50">{t.name}</div><div className="text-[11px] text-zinc-400">{t.members.length} 名成员</div></div>
+                        </div>
+                        <div className="flex flex-1 flex-col px-4 pb-3.5 pt-3">
+                          <p className="mb-3 line-clamp-2 min-h-[34px] text-[12px] leading-relaxed text-zinc-400">{t.desc}</p>
+                          <div className="mb-3 flex items-center">
+                            <div className="flex">
+                              {t.members.slice(0, 6).map((mm, i) => (
+                                <span key={i} title={`${mm.name} · ${mm.role}`} className={`grid h-8 w-8 place-items-center rounded-full bg-gradient-to-br ${GRAD[mm.accent] ?? GRAD.sky} text-sm ring-2 ring-[#101014] ${i > 0 ? '-ml-2' : ''}`}>{mm.emoji}</span>
+                              ))}
+                            </div>
+                            <div className="ml-2 flex flex-wrap gap-1">{t.tags.map((tag) => <span key={tag} className="rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10.5px] text-zinc-500">{tag}</span>)}</div>
+                          </div>
+                          <button data-id={`market-build-${t.key}`} onClick={() => buildTeam(t)} className={`mt-auto inline-flex w-full items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-colors ${built ? 'bg-emerald-500/15 text-emerald-300' : 'bg-sky-500 text-white hover:bg-sky-400'}`}>
+                            {built ? <><Check className="h-4 w-4" /> 已组建（可再建）</> : <><Users className="h-4 w-4" /> 一键组建团队</>}
+                          </button>
                         </div>
                       </div>
-                      <p className="mb-2.5 line-clamp-2 min-h-[34px] text-[12px] leading-relaxed text-zinc-400">{t.desc}</p>
-                      <div className="mb-3 flex flex-wrap gap-1">
-                        {t.tags.map((tag) => <span key={tag} className="rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10.5px] text-zinc-500">{tag}</span>)}
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div data-id="market-grid" className="flex-1 overflow-auto px-6 py-5">
+              {agents.length === 0 ? <div className="grid h-full place-items-center text-[13px] text-zinc-600">没有匹配的模版</div> : (
+                <div className="grid gap-3.5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(248px, 1fr))' }}>
+                  {agents.map((t) => {
+                    const isAdded = added.has(t.key);
+                    return (
+                      <div key={t.key} data-id={`market-card-${t.key}`} className="group flex flex-col rounded-2xl border border-white/[0.07] bg-[#101014] p-3.5 transition-colors hover:border-white/15">
+                        <div className="mb-2 flex items-center gap-2.5">
+                          <span className={`grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-gradient-to-br ${GRAD[t.accent] ?? GRAD.sky} text-xl ring-1 ring-white/10`}>{t.emoji}</span>
+                          <div className="min-w-0"><div className="truncate text-[14px] font-semibold text-zinc-100">{t.name}</div><div className="truncate font-mono text-[11px] text-zinc-500">{t.role}</div></div>
+                        </div>
+                        <p className="mb-2.5 line-clamp-2 min-h-[34px] text-[12px] leading-relaxed text-zinc-400">{t.desc}</p>
+                        <div className="mb-3 flex flex-wrap gap-1">{t.tags.map((tag) => <span key={tag} className="rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10.5px] text-zinc-500">{tag}</span>)}</div>
+                        <div className="mt-auto flex items-center gap-2">
+                          <span className="truncate rounded bg-white/[0.05] px-1.5 py-0.5 font-mono text-[10px] text-zinc-500" title={`默认模型 ${t.model}`}>{t.model}</span>
+                          <button data-id={`market-add-${t.key}`} onClick={() => pickAgent(t)} className={`ml-auto inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px] font-medium transition-colors ${isAdded ? 'bg-emerald-500/15 text-emerald-300' : 'bg-sky-500 text-white hover:bg-sky-400'}`}>
+                            {isAdded ? <><Check className="h-3.5 w-3.5" /> 已添加</> : <><Plus className="h-3.5 w-3.5" /> 添加</>}
+                          </button>
+                        </div>
                       </div>
-                      <div className="mt-auto flex items-center gap-2">
-                        <span className="truncate rounded bg-white/[0.05] px-1.5 py-0.5 font-mono text-[10px] text-zinc-500" title={`默认模型 ${t.model}`}>{t.model}</span>
-                        <button data-id={`market-add-${t.key}`} onClick={() => pick(t)}
-                          className={`ml-auto inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px] font-medium transition-colors ${isAdded ? 'bg-emerald-500/15 text-emerald-300' : 'bg-sky-500 text-white hover:bg-sky-400'}`}>
-                          {isAdded ? <><Check className="h-3.5 w-3.5" /> 已添加</> : <><Plus className="h-3.5 w-3.5" /> 添加</>}
-                        </button>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
-          </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          )}
 
           <footer className="flex shrink-0 items-center justify-between border-t border-white/[0.06] px-6 py-3 text-[12px] text-zinc-500">
-            <span>共 {MARKET.length} 个模版 · 已添加 {added.size}</span>
+            <span>{view === 'team' ? `${TEAMS.length} 支团队 · 已组建 ${builtTeams.size}` : `${MARKET.length} 个模版 · 已添加 ${added.size}`}</span>
             <button data-id="market-done" onClick={onClose} className="rounded-lg bg-white/[0.06] px-4 py-1.5 text-zinc-200 hover:bg-white/[0.12]">完成</button>
           </footer>
         </div>

--- a/app/src/components/office/TemplateMarket.tsx
+++ b/app/src/components/office/TemplateMarket.tsx
@@ -1,0 +1,186 @@
+import { useMemo, useState } from 'react';
+import {
+  X, Search, Check, Plus, LayoutGrid, Code2, PenTool, BarChart3, Megaphone,
+  ShoppingCart, Palette, Briefcase, Headphones, Store,
+} from 'lucide-react';
+
+/*
+ * TemplateMarket —「Agent 模版市场」全屏大屏（data-id="template-market"）。
+ * 各行各业的预置 agent 模版，按分类浏览 / 搜索 / 一键添加到办公室。
+ * 纯 UI 原型；onPick 把选中模版交给 Office 在画布上创建成员。
+ */
+
+export interface MarketTmpl { key: string; cat: string; name: string; role: string; emoji: string; accent: string; model: string; desc: string; tags: string[] }
+
+const CATEGORIES: { key: string; name: string; icon: any }[] = [
+  { key: 'all', name: '全部', icon: LayoutGrid },
+  { key: 'dev', name: '软件研发', icon: Code2 },
+  { key: 'content', name: '内容创作', icon: PenTool },
+  { key: 'data', name: '数据分析', icon: BarChart3 },
+  { key: 'mkt', name: '市场营销', icon: Megaphone },
+  { key: 'ecom', name: '电商运营', icon: ShoppingCart },
+  { key: 'design', name: '设计创意', icon: Palette },
+  { key: 'biz', name: '商业职能', icon: Briefcase },
+  { key: 'cs', name: '客服支持', icon: Headphones },
+];
+
+const GRAD: Record<string, string> = {
+  sky: 'from-sky-500/45 to-sky-700/15', violet: 'from-violet-500/45 to-violet-700/15',
+  emerald: 'from-emerald-500/45 to-emerald-700/15', amber: 'from-amber-500/45 to-amber-700/15',
+  rose: 'from-rose-500/45 to-rose-700/15',
+};
+
+const T = (key: string, cat: string, name: string, role: string, emoji: string, accent: string, model: string, desc: string, tags: string[]): MarketTmpl =>
+  ({ key, cat, name, role, emoji, accent, model, desc, tags });
+
+const MARKET: MarketTmpl[] = [
+  // 软件研发
+  T('arch', 'dev', '架构师', 'dev-senior', '🏛️', 'sky', 'deepseek-v4-pro', '拆解需求、定义接口与目录结构、做关键技术选型并把关 review。', ['架构', '选型', 'review']),
+  T('fe', 'dev', '前端工程师', 'dev-junior', '🎨', 'sky', 'deepseek-v4-pro', '实现页面与组件，关注交互细节、可访问性与性能。', ['React', 'UI', 'a11y']),
+  T('be', 'dev', '后端工程师', 'dev', '🛠️', 'sky', 'deepseek-v4-pro', 'API 设计、数据库与服务端逻辑，保证一致性与性能。', ['API', 'DB', '服务']),
+  T('qa', 'dev', '测试工程师', 'qa', '🧪', 'sky', 'gpt-5.5', '编写/执行用例、跑回归、核对验收标准并出 PASS/FAIL。', ['测试', '回归', '验收']),
+  T('ops', 'dev', 'DevOps', 'ops', '🚀', 'sky', 'deepseek-v4-pro', '构建、部署、发布与回滚，线上监控与告警。', ['CI/CD', '部署', '监控']),
+  T('sec', 'dev', '安全工程师', 'reviewer', '🛡️', 'sky', 'claude-haiku-4-5', '密钥/注入/权限/依赖风险审查，出安全结论。', ['安全', '审计']),
+  // 内容创作
+  T('copy', 'content', '文案策划', 'writer', '✍️', 'violet', 'deepseek-v4-pro', '营销文案、卖点提炼、不同渠道的语气适配。', ['文案', '营销']),
+  T('script', 'content', '短视频编剧', 'scriptwriter', '🎬', 'violet', 'gpt-5.5', '脚本、分镜、开头钩子与节奏设计。', ['脚本', '短视频']),
+  T('seo', 'content', 'SEO 编辑', 'seo', '🔍', 'violet', 'deepseek-v4-pro', '关键词与长尾布局、内容结构优化。', ['SEO', '内容']),
+  T('trans', 'content', '翻译/本地化', 'translator', '🌐', 'violet', 'deepseek-v4-pro', '多语翻译与本地化，保留语气与术语一致。', ['翻译', 'i18n']),
+  T('media', 'content', '新媒体运营', 'editor', '📣', 'violet', 'deepseek-v4-pro', '选题、排版、推送与互动追踪。', ['新媒体', '排版']),
+  // 数据分析
+  T('analyst', 'data', '数据分析师', 'analyst', '📊', 'emerald', 'gpt-5.5', '指标体系、报表与可执行洞察。', ['SQL', '报表', '洞察']),
+  T('bi', 'data', 'BI 工程师', 'bi', '📈', 'emerald', 'deepseek-v4-pro', '看板搭建与数据可视化。', ['BI', '可视化']),
+  T('de', 'data', '数据工程', 'data-eng', '🗄️', 'emerald', 'deepseek-v4-pro', '数据管道、清洗与数仓建模。', ['ETL', '数仓']),
+  T('ml', 'data', 'ML 工程师', 'ml', '🤖', 'emerald', 'gpt-5.5', '特征、建模、训练与评估。', ['ML', '建模']),
+  // 市场营销
+  T('growth', 'mkt', '增长黑客', 'growth', '📈', 'amber', 'gpt-5.5', '增长实验设计、漏斗分析与迭代。', ['增长', '实验']),
+  T('ads', 'mkt', '投放优化', 'ads', '🎯', 'amber', 'deepseek-v4-pro', '广告投放策略与 ROI 优化。', ['投放', 'ROI']),
+  T('social', 'mkt', '社媒运营', 'social', '💬', 'amber', 'deepseek-v4-pro', '内容日历、互动与社群运营。', ['社媒', '运营']),
+  T('brand', 'mkt', '品牌策划', 'brand', '✨', 'amber', 'deepseek-v4-pro', '品牌定位、叙事与视觉调性。', ['品牌', '叙事']),
+  // 电商运营
+  T('shop', 'ecom', '店铺运营', 'ecom', '🛒', 'rose', 'deepseek-v4-pro', '上架、活动排期与数据复盘。', ['电商', '运营']),
+  T('sel', 'ecom', '选品分析', 'selection', '🔎', 'rose', 'gpt-5.5', '选品、趋势与利润测算。', ['选品', '趋势']),
+  T('detail', 'ecom', '详情页文案', 'writer', '🏷️', 'rose', 'deepseek-v4-pro', '详情页结构与卖点转化。', ['详情页', '转化']),
+  T('after', 'ecom', '售后助理', 'cs', '📦', 'rose', 'deepseek-v4-pro', '退换货、纠纷与售后流程。', ['售后', '工单']),
+  // 设计创意
+  T('ui', 'design', 'UI 设计', 'ui-design', '🖌️', 'violet', 'deepseek-v4-pro', '界面设计与组件规范。', ['UI', '规范']),
+  T('graphic', 'design', '平面设计', 'graphic', '🎨', 'violet', 'deepseek-v4-pro', '海报、物料与视觉输出。', ['平面', '物料']),
+  T('illus', 'design', '插画师', 'illustrator', '🖼️', 'violet', 'deepseek-v4-pro', '插画风格与配图。', ['插画', '风格']),
+  T('vi', 'design', '品牌设计', 'brand-design', '🅰️', 'violet', 'deepseek-v4-pro', 'VI 系统与 logo 设计。', ['VI', 'logo']),
+  // 商业职能
+  T('pm', 'biz', '产品经理', 'pm', '📋', 'sky', 'gpt-5.5', '需求梳理、PRD 与优先级排布。', ['PRD', '需求']),
+  T('pmo', 'biz', '项目经理', 'pmo', '🗂️', 'sky', 'deepseek-v4-pro', '排期、风险与跨角色协调。', ['排期', '风险']),
+  T('fin', 'biz', '财务分析', 'finance', '💰', 'sky', 'gpt-5.5', '预算、报表与商业测算。', ['财务', '测算']),
+  T('legal', 'biz', '法务顾问', 'legal', '⚖️', 'sky', 'claude-haiku-4-5', '合同审阅、合规与风险提示。', ['合同', '合规']),
+  T('hr', 'biz', 'HR 招聘', 'hr', '🧑‍💼', 'sky', 'deepseek-v4-pro', 'JD 撰写、简历筛选与面评。', ['招聘', 'JD']),
+  // 客服支持
+  T('support', 'cs', '智能客服', 'support', '🎧', 'emerald', 'deepseek-v4-pro', '多轮答疑、FAQ 与转人工。', ['客服', 'FAQ']),
+  T('triage', 'cs', '工单分类', 'triage', '🧭', 'emerald', 'gpt-5.5', '工单分类、优先级与路由。', ['工单', '路由']),
+  T('kb', 'cs', '知识库维护', 'kb', '📚', 'emerald', 'deepseek-v4-pro', '知识沉淀、更新与检索。', ['KB', '检索']),
+];
+
+export default function TemplateMarket({ open, onClose, onPick }: {
+  open: boolean; onClose: () => void; onPick: (t: MarketTmpl) => void;
+}) {
+  const [cat, setCat] = useState('all');
+  const [q, setQ] = useState('');
+  const [added, setAdded] = useState<Set<string>>(new Set());
+
+  const counts = useMemo(() => {
+    const m: Record<string, number> = { all: MARKET.length };
+    for (const t of MARKET) m[t.cat] = (m[t.cat] || 0) + 1;
+    return m;
+  }, []);
+
+  const list = useMemo(() => {
+    const kw = q.trim().toLowerCase();
+    return MARKET.filter((t) => (cat === 'all' || t.cat === cat) &&
+      (!kw || t.name.toLowerCase().includes(kw) || t.role.toLowerCase().includes(kw) || t.desc.toLowerCase().includes(kw) || t.tags.some((x) => x.toLowerCase().includes(kw))));
+  }, [cat, q]);
+
+  if (!open) return null;
+
+  const pick = (t: MarketTmpl) => { onPick(t); setAdded((s) => new Set(s).add(t.key)); };
+
+  return (
+    <div data-id="template-market" className="absolute inset-0 z-[200] flex items-center justify-center bg-black/70 p-6 backdrop-blur-sm" onPointerDown={onClose}>
+      <div className="relative flex h-[88vh] w-[1120px] max-w-[96vw] overflow-hidden rounded-2xl border border-white/10 bg-[#0b0b0e] shadow-2xl" onPointerDown={(e) => e.stopPropagation()}>
+        {/* 左：分类 */}
+        <aside data-id="market-cats" className="flex w-52 shrink-0 flex-col border-r border-white/[0.06] bg-[#0d0d10]">
+          <div className="flex items-center gap-2 px-4 py-4 text-zinc-100">
+            <Store className="h-5 w-5 text-sky-400" />
+            <span className="text-[14px] font-semibold">模版市场</span>
+          </div>
+          <div className="flex-1 space-y-0.5 overflow-auto px-2 pb-3">
+            {CATEGORIES.map((c) => {
+              const Icon = c.icon; const on = cat === c.key;
+              return (
+                <button key={c.key} data-id={`market-cat-${c.key}`} onClick={() => setCat(c.key)}
+                  className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors ${on ? 'bg-white/[0.08] text-zinc-100' : 'text-zinc-400 hover:bg-white/[0.04] hover:text-zinc-200'}`}>
+                  <Icon className={`h-4 w-4 ${on ? 'text-sky-400' : 'text-zinc-500'}`} />
+                  <span className="flex-1">{c.name}</span>
+                  <span className="text-[11px] text-zinc-600">{counts[c.key] || 0}</span>
+                </button>
+              );
+            })}
+          </div>
+        </aside>
+
+        {/* 右：标题 + 搜索 + 卡网格 */}
+        <div className="flex min-w-0 flex-1 flex-col">
+          <header className="flex shrink-0 items-center gap-3 border-b border-white/[0.06] px-6 py-4">
+            <div className="min-w-0 flex-1">
+              <div className="text-[17px] font-semibold text-zinc-100">Agent 模版市场</div>
+              <div className="text-[12px] text-zinc-500">各行各业的预置 agent，一键加入你的办公室</div>
+            </div>
+            <div className="relative w-72 max-w-[40%]">
+              <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500" />
+              <input data-id="market-search" value={q} onChange={(e) => setQ(e.target.value)} placeholder="搜索角色 / 技能 / 行业…"
+                className="w-full rounded-lg border border-white/10 bg-[#141418] py-2 pl-8 pr-3 text-[13px] text-zinc-200 outline-none placeholder:text-zinc-600 focus:border-white/25" />
+            </div>
+            <button data-id="market-close" onClick={onClose} className="grid h-8 w-8 place-items-center rounded-lg text-zinc-500 hover:bg-white/10 hover:text-zinc-200"><X className="h-4.5 w-4.5" /></button>
+          </header>
+
+          <div data-id="market-grid" className="flex-1 overflow-auto px-6 py-5">
+            {list.length === 0 ? (
+              <div className="grid h-full place-items-center text-[13px] text-zinc-600">没有匹配的模版</div>
+            ) : (
+              <div className="grid gap-3.5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(248px, 1fr))' }}>
+                {list.map((t) => {
+                  const isAdded = added.has(t.key);
+                  return (
+                    <div key={t.key} data-id={`market-card-${t.key}`} className="group flex flex-col rounded-2xl border border-white/[0.07] bg-[#101014] p-3.5 transition-colors hover:border-white/15">
+                      <div className="mb-2 flex items-center gap-2.5">
+                        <span className={`grid h-11 w-11 shrink-0 place-items-center rounded-xl bg-gradient-to-br ${GRAD[t.accent] ?? GRAD.sky} text-xl ring-1 ring-white/10`}>{t.emoji}</span>
+                        <div className="min-w-0">
+                          <div className="truncate text-[14px] font-semibold text-zinc-100">{t.name}</div>
+                          <div className="truncate font-mono text-[11px] text-zinc-500">{t.role}</div>
+                        </div>
+                      </div>
+                      <p className="mb-2.5 line-clamp-2 min-h-[34px] text-[12px] leading-relaxed text-zinc-400">{t.desc}</p>
+                      <div className="mb-3 flex flex-wrap gap-1">
+                        {t.tags.map((tag) => <span key={tag} className="rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10.5px] text-zinc-500">{tag}</span>)}
+                      </div>
+                      <div className="mt-auto flex items-center gap-2">
+                        <span className="truncate rounded bg-white/[0.05] px-1.5 py-0.5 font-mono text-[10px] text-zinc-500" title={`默认模型 ${t.model}`}>{t.model}</span>
+                        <button data-id={`market-add-${t.key}`} onClick={() => pick(t)}
+                          className={`ml-auto inline-flex items-center gap-1 rounded-lg px-2.5 py-1.5 text-[12px] font-medium transition-colors ${isAdded ? 'bg-emerald-500/15 text-emerald-300' : 'bg-sky-500 text-white hover:bg-sky-400'}`}>
+                          {isAdded ? <><Check className="h-3.5 w-3.5" /> 已添加</> : <><Plus className="h-3.5 w-3.5" /> 添加</>}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          <footer className="flex shrink-0 items-center justify-between border-t border-white/[0.06] px-6 py-3 text-[12px] text-zinc-500">
+            <span>共 {MARKET.length} 个模版 · 已添加 {added.size}</span>
+            <button data-id="market-done" onClick={onClose} className="rounded-lg bg-white/[0.06] px-4 py-1.5 text-zinc-200 hover:bg-white/[0.12]">完成</button>
+          </footer>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/office/TemplateMarket.tsx
+++ b/app/src/components/office/TemplateMarket.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   X, Search, Check, Plus, LayoutGrid, Code2, PenTool, BarChart3, Megaphone,
-  ShoppingCart, Palette, Briefcase, Headphones, Store, Users, Sparkles,
+  ShoppingCart, Palette, Briefcase, Headphones, Store, Users, Sparkles, ChevronLeft, ChevronRight,
 } from 'lucide-react';
 
 /*
@@ -158,13 +158,15 @@ const TEAMS: TeamTmpl[] = [
 ];
 
 export default function TemplateMarket({ open, onClose, onPick, onPickTeam }: {
-  open: boolean; onClose: () => void; onPick: (t: MarketTmpl) => void; onPickTeam: (t: TeamTmpl) => void;
+  open: 'team' | 'agent' | null; onClose: () => void; onPick: (t: MarketTmpl) => void; onPickTeam: (t: TeamTmpl) => void;
 }) {
   const [view, setView] = useState<'team' | 'agent'>('team');
   const [cat, setCat] = useState('all');
   const [q, setQ] = useState('');
   const [added, setAdded] = useState<Set<string>>(new Set());
   const [builtTeams, setBuiltTeams] = useState<Set<string>>(new Set());
+  const [previewKey, setPreviewKey] = useState<string | null>(null);
+  useEffect(() => { if (open) { setView(open); setCat('all'); setQ(''); setPreviewKey(null); } }, [open]);
 
   const cats = view === 'team' ? TEAM_CATS : AGENT_CATS;
   const counts = useMemo(() => {
@@ -184,9 +186,10 @@ export default function TemplateMarket({ open, onClose, onPick, onPickTeam }: {
   }, [cat, q]);
 
   if (!open) return null;
-  const switchView = (v: 'team' | 'agent') => { setView(v); setCat('all'); setQ(''); };
+  const switchView = (v: 'team' | 'agent') => { setView(v); setCat('all'); setQ(''); setPreviewKey(null); };
   const pickAgent = (t: MarketTmpl) => { onPick(t); setAdded((s) => new Set(s).add(t.key)); };
   const buildTeam = (t: TeamTmpl) => { onPickTeam(t); setBuiltTeams((s) => new Set(s).add(t.key)); };
+  const previewTeam = previewKey ? TEAMS.find((t) => t.key === previewKey) || null : null;
 
   return (
     <div data-id="template-market" className="absolute inset-0 z-[200] flex items-center justify-center bg-black/70 p-6 backdrop-blur-sm" onPointerDown={onClose}>
@@ -226,37 +229,59 @@ export default function TemplateMarket({ open, onClose, onPick, onPickTeam }: {
           </header>
 
           {view === 'team' ? (
+            previewTeam ? (
+              <div data-id="market-team-detail" className="flex-1 overflow-auto px-6 py-5">
+                <button data-id="market-team-back" onClick={() => setPreviewKey(null)} className="mb-4 inline-flex items-center gap-1 text-[12.5px] text-zinc-400 transition-colors hover:text-zinc-100"><ChevronLeft className="h-4 w-4" /> 返回团队</button>
+                <div className={`mb-5 flex items-center gap-4 rounded-2xl bg-gradient-to-r ${COVER[previewTeam.accent] ?? COVER.sky} p-5`}>
+                  <span className={`grid h-16 w-16 shrink-0 place-items-center rounded-2xl bg-gradient-to-br ${GRAD[previewTeam.accent] ?? GRAD.sky} text-3xl ring-1 ring-white/15`}>{previewTeam.emoji}</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-[18px] font-semibold text-zinc-50">{previewTeam.name}</div>
+                    <div className="mb-1 flex items-center gap-2 text-[12px] text-zinc-400">{previewTeam.members.length} 名成员 {previewTeam.tags.map((tag) => <span key={tag} className="rounded-md bg-white/10 px-1.5 py-0.5 text-[10.5px]">{tag}</span>)}</div>
+                    <p className="text-[12.5px] leading-relaxed text-zinc-300">{previewTeam.desc}</p>
+                  </div>
+                </div>
+                <div className="mb-2.5 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-zinc-500"><Users className="h-3 w-3" /> 阵容预览</div>
+                <div className="mb-6 grid gap-2.5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(264px, 1fr))' }}>
+                  {previewTeam.members.map((mm, i) => (
+                    <div key={i} data-id={`market-member-${i}`} className="flex items-center gap-2.5 rounded-xl border border-white/[0.07] bg-[#101014] px-3 py-2.5">
+                      <span className={`grid h-10 w-10 shrink-0 place-items-center rounded-xl bg-gradient-to-br ${GRAD[mm.accent] ?? GRAD.sky} text-lg ring-1 ring-white/10`}>{mm.emoji}</span>
+                      <div className="min-w-0 flex-1"><div className="truncate text-[13px] font-medium text-zinc-100">{mm.name}</div><div className="truncate font-mono text-[11px] text-zinc-500">{mm.role}</div></div>
+                      <span className="truncate rounded bg-white/[0.05] px-1.5 py-0.5 font-mono text-[10px] text-zinc-500" title={`默认模型 ${mm.model}`}>{mm.model}</span>
+                    </div>
+                  ))}
+                </div>
+                <button data-id={`market-build-${previewTeam.key}`} onClick={() => buildTeam(previewTeam)} className={`inline-flex items-center justify-center gap-1.5 rounded-xl px-5 py-2.5 text-[13.5px] font-medium transition-colors ${builtTeams.has(previewTeam.key) ? 'bg-emerald-500/15 text-emerald-300' : 'bg-sky-500 text-white hover:bg-sky-400'}`}>
+                  {builtTeams.has(previewTeam.key) ? <><Check className="h-4 w-4" /> 已组建（可再次组建）</> : <><Users className="h-4 w-4" /> 组建团队 · {previewTeam.members.length} 人加入办公室</>}
+                </button>
+              </div>
+            ) : (
             <div data-id="market-team-grid" className="flex-1 overflow-auto px-6 py-5">
               {teams.length === 0 ? <div className="grid h-full place-items-center text-[13px] text-zinc-600">没有匹配的团队</div> : (
                 <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}>
-                  {teams.map((t) => {
-                    const built = builtTeams.has(t.key);
-                    return (
-                      <div key={t.key} data-id={`market-team-${t.key}`} className="group flex flex-col overflow-hidden rounded-2xl border border-white/[0.08] bg-[#101014] transition-colors hover:border-white/20">
-                        <div className={`relative flex h-20 items-center gap-3 bg-gradient-to-r ${COVER[t.accent] ?? COVER.sky} px-4`}>
-                          <span className={`grid h-12 w-12 place-items-center rounded-xl bg-gradient-to-br ${GRAD[t.accent] ?? GRAD.sky} text-2xl ring-1 ring-white/15`}>{t.emoji}</span>
-                          <div className="min-w-0"><div className="truncate text-[15px] font-semibold text-zinc-50">{t.name}</div><div className="text-[11px] text-zinc-400">{t.members.length} 名成员</div></div>
-                        </div>
-                        <div className="flex flex-1 flex-col px-4 pb-3.5 pt-3">
-                          <p className="mb-3 line-clamp-2 min-h-[34px] text-[12px] leading-relaxed text-zinc-400">{t.desc}</p>
-                          <div className="mb-3 flex items-center">
-                            <div className="flex">
-                              {t.members.slice(0, 6).map((mm, i) => (
-                                <span key={i} title={`${mm.name} · ${mm.role}`} className={`grid h-8 w-8 place-items-center rounded-full bg-gradient-to-br ${GRAD[mm.accent] ?? GRAD.sky} text-sm ring-2 ring-[#101014] ${i > 0 ? '-ml-2' : ''}`}>{mm.emoji}</span>
-                              ))}
-                            </div>
-                            <div className="ml-2 flex flex-wrap gap-1">{t.tags.map((tag) => <span key={tag} className="rounded-md bg-white/[0.05] px-1.5 py-0.5 text-[10.5px] text-zinc-500">{tag}</span>)}</div>
+                  {teams.map((t) => (
+                    <button key={t.key} data-id={`market-team-${t.key}`} onClick={() => setPreviewKey(t.key)} className="group flex flex-col overflow-hidden rounded-2xl border border-white/[0.08] bg-[#101014] text-left transition-colors hover:border-white/20">
+                      <div className={`relative flex h-20 items-center gap-3 bg-gradient-to-r ${COVER[t.accent] ?? COVER.sky} px-4`}>
+                        <span className={`grid h-12 w-12 place-items-center rounded-xl bg-gradient-to-br ${GRAD[t.accent] ?? GRAD.sky} text-2xl ring-1 ring-white/15`}>{t.emoji}</span>
+                        <div className="min-w-0"><div className="truncate text-[15px] font-semibold text-zinc-50">{t.name}</div><div className="text-[11px] text-zinc-400">{t.members.length} 名成员</div></div>
+                        <ChevronRight className="ml-auto h-4 w-4 text-zinc-400" />
+                      </div>
+                      <div className="flex flex-1 flex-col px-4 pb-3.5 pt-3">
+                        <p className="mb-3 line-clamp-2 min-h-[34px] text-[12px] leading-relaxed text-zinc-400">{t.desc}</p>
+                        <div className="flex items-center">
+                          <div className="flex">
+                            {t.members.slice(0, 6).map((mm, i) => (
+                              <span key={i} title={`${mm.name} · ${mm.role}`} className={`grid h-8 w-8 place-items-center rounded-full bg-gradient-to-br ${GRAD[mm.accent] ?? GRAD.sky} text-sm ring-2 ring-[#101014] ${i > 0 ? '-ml-2' : ''}`}>{mm.emoji}</span>
+                            ))}
                           </div>
-                          <button data-id={`market-build-${t.key}`} onClick={() => buildTeam(t)} className={`mt-auto inline-flex w-full items-center justify-center gap-1.5 rounded-xl py-2 text-[13px] font-medium transition-colors ${built ? 'bg-emerald-500/15 text-emerald-300' : 'bg-sky-500 text-white hover:bg-sky-400'}`}>
-                            {built ? <><Check className="h-4 w-4" /> 已组建（可再建）</> : <><Users className="h-4 w-4" /> 一键组建团队</>}
-                          </button>
+                          <span className="ml-auto text-[11px] text-sky-300">查看阵容 ›</span>
                         </div>
                       </div>
-                    );
-                  })}
+                    </button>
+                  ))}
                 </div>
               )}
             </div>
+            )
           ) : (
             <div data-id="market-grid" className="flex-1 overflow-auto px-6 py-5">
               {agents.length === 0 ? <div className="grid h-full place-items-center text-[13px] text-zinc-600">没有匹配的模版</div> : (


### PR DESCRIPTION
w-10001's office UI commit (d45ad77), pushed to its own branch so it isn't lost as a local-only commit. It did **not** ride into PR #22 (it was committed locally but never pushed before that merge).

- Office.tsx — two-column office UI (command dialog + worker chat grid)
- AgentCanvas.tsx — early pan/zoom canvas prototype (kept for reference)
- Workspace.tsx — activity-bar btn-office wires in Office (full-screen office view)

Author: w-10001. @w-10001 — over to you; reassign/adjust as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)